### PR TITLE
Fix Poetry installation failure in python-dev Dockerfile

### DIFF
--- a/workspace-images/python-dev/Dockerfile
+++ b/workspace-images/python-dev/Dockerfile
@@ -40,7 +40,7 @@ RUN python3 -m pip install --no-cache-dir --break-system-packages \
     twine build
 
 # Install Poetry via pip (as requested - not via official installer)
-RUN python3 -m pip install --no-cache-dir --break-system-packages poetry
+RUN python3 -m pip install --no-cache-dir --break-system-packages --ignore-installed poetry
 
 # Create Python-specific init script
 COPY workspace-images/python-dev/python-init.sh /usr/local/share/workspace-init.d/20-python-init.sh

--- a/workspace-images/python-dev/Dockerfile
+++ b/workspace-images/python-dev/Dockerfile
@@ -39,13 +39,8 @@ RUN python3 -m pip install --no-cache-dir --break-system-packages \
     sphinx sphinx-rtd-theme \
     twine build
 
-# Install Poetry via pip with staged dependency resolution (as requested - not via official installer)
-# Handle platformdirs conflict by installing Poetry's dependencies first, then Poetry
-RUN python3 -m pip install --no-cache-dir --break-system-packages \
-    setuptools wheel && \
-    python3 -m pip install --no-cache-dir --break-system-packages \
-    --ignore-installed platformdirs && \
-    python3 -m pip install --no-cache-dir --break-system-packages poetry
+# Install Poetry via pip (as requested - not via official installer)
+RUN python3 -m pip install --no-cache-dir --break-system-packages poetry
 
 # Create Python-specific init script
 COPY workspace-images/python-dev/python-init.sh /usr/local/share/workspace-init.d/20-python-init.sh


### PR DESCRIPTION
## Summary
- Fixes Poetry installation failure in python-dev Docker image
- Resolves debian package conflicts that prevented Poetry from installing
- Adds `--ignore-installed` flag to bypass package conflict resolution

## Root Cause
The base image contains debian-managed packages (`platformdirs`, `packaging`) that Poetry tries to upgrade during installation. However, pip cannot uninstall debian-managed packages because they lack RECORD files, causing the installation to fail with:

```
ERROR: Cannot uninstall platformdirs 4.2.0, RECORD file not found. Hint: The package was installed by debian.
```

## Solution
Added `--ignore-installed` flag to the Poetry pip installation command:

```dockerfile
RUN python3 -m pip install --no-cache-dir --break-system-packages --ignore-installed poetry
```

This allows Poetry to install its own versions of conflicting packages without attempting to uninstall the debian-managed versions.

## Test Results
- ✅ Poetry 2.2.1 installs successfully
- ✅ Complete python-dev Docker build passes
- ✅ All other Python packages install correctly
- ✅ Maintains user requirement to install Poetry via pip (not official installer)

## Test plan
- [x] Verify Poetry installation works with --ignore-installed flag
- [x] Build complete python-dev Docker image successfully
- [x] Confirm Poetry version and functionality
- [x] Validate all other Python packages install correctly

🤖 Generated with [Claude Code](https://claude.ai/code)