### PR TITLE
Fix: Add -f flag to pgrep for gnome-keyring-daemon

### DIFF
--- a/workspace-images/base-dev/init-workspace.sh
+++ b/workspace-images/base-dev/init-workspace.sh
@@ -64,7 +64,7 @@ if command -v gnome-keyring-daemon >/dev/null 2>&1; then
   export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
 
   # Start gnome-keyring-daemon if not already running
-  if ! pgrep -u "$(id -u)" gnome-keyring-daemon >/dev/null 2>&1; then
+  if ! pgrep -u "$(id -u)" -f gnome-keyring-daemon >/dev/null 2>&1; then
     log "starting gnome-keyring-daemon"
     gnome-keyring-daemon --start --components=secrets,ssh,gpg,pkcs11 >/tmp/gnome-keyring.log 2>&1 &
     sleep 1  # Give it a moment to start and create sockets
@@ -93,7 +93,7 @@ if command -v gnome-keyring-daemon >/dev/null 2>&1; then
   fi
 
   # Get daemon PID
-  GNOME_KEYRING_PID=$(pgrep -u "$(id -u)" gnome-keyring-daemon)
+  GNOME_KEYRING_PID=$(pgrep -u "$(id -u)" -f gnome-keyring-daemon)
   export GNOME_KEYRING_PID
 
   # Export for current session and all child processes (following GCP secrets pattern)


### PR DESCRIPTION
## Summary
Fixes the `pgrep` error that was preventing keyring environment variables from being set, which caused the `.keyring-env` file to be written empty.

## Problem
The process name "gnome-keyring-daemon" exceeds pgrep's 15-character limit, causing:
```
pgrep: pattern that searches for process name longer than 15 characters will result in zero matches
Try `pgrep -f' option to match against the complete command line.
```

This error occurred in two places:
1. **Line 67**: When checking if daemon is already running
2. **Line 96**: When getting daemon PID for environment export

Because line 96 failed silently, `GNOME_KEYRING_PID` was never set, causing the `.keyring-env` file to be written with empty variables.

## Solution
Add the `-f` flag to both `pgrep` calls to match against the full command line instead of just the process name.

## Impact
- ✅ Keyring daemon PID is now properly detected
- ✅ `.keyring-env` file gets populated with correct values
- ✅ VS Code Web can now access the keyring and persist GitHub credentials

## Testing
After this fix is merged and the Docker image is rebuilt:
1. Start a new workspace
2. Check `/tmp/workspace-init.log` - no more pgrep errors
3. Verify `.keyring-env` contains actual values:
   ```bash
   cat ~/.keyring-env
   ```
4. Sign in to GitHub in VS Code
5. Restart workspace - credentials should persist ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)