### PR TITLE
Unify skill catalogs under ~/.agents/skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,11 +150,28 @@ agent's expected read path so Coder Agents (chatd) and in-workspace CLIs
   `DefaultInstructionsFile`). It then symlinks `~/.claude/CLAUDE.md`,
   `~/.codex/AGENTS.md`, and `~/.gemini/GEMINI.md` to that canonical file so
   there's a single source of truth with zero content duplication.
-- `~/.coder/skills` is symlinked to `~/.claude/skills` so Coder Agents and
-  Claude Code share one skill catalog. Both follow the
+- Skill catalogs are unified under one canonical at `~/.agents/skills` (where
+  the `skills` npm CLI installs natively — persistent across workspaces via
+  the host bind mount on `/home/ubuntu/secrets/.agents`). Each agent's
+  skills/ path is a folder-level symlink to the canonical:
+  `~/.claude/skills`, `~/.codex/skills`, `~/.gemini/skills`, and
+  `~/.coder/skills` all resolve to the same directory. Coder Agents (chatd)
+  doesn't auto-discover `~/.agents/skills` — its built-in `SkillsDir`
+  default is `.agents/skills` resolved relative to the project dir. The
+  `coder_agent` env in `workspace-templates/project-workspace/main.tf`
+  sets `CODER_AGENT_EXP_SKILLS_DIRS=~/.agents/skills,.agents/skills` so
+  chatd reads both user-level and project-local catalogs. All follow the
   [agentskills.io](https://agentskills.io) `SKILL.md` format.
-- Existing user-edited regular files are NOT overwritten — the symlink helper
-  only replaces broken/missing links.
+- First-run migration in `11-agent-prompts.sh` converts each per-agent
+  skills/ real directory into a folder-level symlink: skills with
+  `SKILL.md` not already in the canonical are adopted; everything else
+  (loose `.md` files, duplicate skill dirs, agent-specific subfolders like
+  Codex's `.system/`) is moved under `~/.agents/skills-migration-backup/`
+  for manual reconciliation. Per-skill symlinks (CLI-managed) are simply
+  removed since the targets already live in the canonical.
+- Existing user-edited regular files outside the skills dirs (e.g.,
+  `~/.claude/CLAUDE.md`) are NOT overwritten — the symlink helper only
+  replaces broken/missing links.
 
 ### Coder Agents Central Config
 

--- a/workspace-images/base-dev/init.d/11-agent-prompts.sh
+++ b/workspace-images/base-dev/init.d/11-agent-prompts.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # 11-agent-prompts.sh — Assemble the workspace system prompt and wire it
-# into every agent's expected read path.
+# into every agent's expected read path. Also normalize skill catalogs so
+# every agent sees the same skills from one canonical folder.
 #
 # How it works:
 #   1. Concatenate /usr/local/share/workspace-prompts/*.txt in sorted order.
@@ -13,8 +14,15 @@
 #      same content is seen by Claude Code, Codex, and Gemini CLIs running
 #      in-workspace. Symlinks are idempotent and preserve any user-edited
 #      regular files (we never overwrite a non-link).
-#   4. Also symlink ~/.coder/skills → ~/.claude/skills so Coder Agents and
-#      Claude Code share one skill catalog.
+#   4. Make ~/.agents/skills the single canonical skill catalog (where the
+#      `skills` npm CLI installs natively) and turn each per-agent skills
+#      directory into a folder-level symlink to it. First run migrates any
+#      pre-existing real-dir contents into the canonical (skills with
+#      SKILL.md not already there are adopted; everything else is moved
+#      under ~/.agents/skills-migration-backup/). Coder Agents must be
+#      told to look at ~/.agents/skills via CODER_AGENT_EXP_SKILLS_DIRS
+#      in the workspace template's coder_agent env (its built-in default
+#      resolves .agents/skills relative to the project dir, not $HOME).
 
 set -u
 
@@ -58,10 +66,66 @@ maybe_link "$CANONICAL" "$HOME/.claude/CLAUDE.md"     # Claude Code
 maybe_link "$CANONICAL" "$HOME/.codex/AGENTS.md"      # Codex CLI
 maybe_link "$CANONICAL" "$HOME/.gemini/GEMINI.md"     # Gemini CLI
 
-# 4. Share skill catalog between Coder Agents (~/.coder/skills) and
-#    Claude Code (~/.claude/skills). Use Claude's path as canonical since
-#    its skill ecosystem is more mature; Coder Agents reads through the link.
-mkdir -p "$HOME/.claude/skills"
-maybe_link "$HOME/.claude/skills" "$HOME/.coder/skills"
+# 4. Single canonical skill catalog at ~/.agents/skills (where the `skills`
+#    CLI installs natively + persistent across workspaces via the host bind
+#    mount on /home/ubuntu/secrets/.agents). Every agent's skills/ path
+#    becomes a folder-level symlink to it. Migration of any pre-existing
+#    real-dir contents is idempotent — skill subdirs with SKILL.md are
+#    adopted into the canonical if not already present; everything else
+#    (loose files, duplicate skill dirs, agent-specific subfolders like
+#    Codex's .system/) lands in ~/.agents/skills-migration-backup/<agent>/
+#    for manual reconciliation.
+mkdir -p "$HOME/.agents/skills"
+
+migrate_skills_dir_to_link() {
+  local link="$1"
+  local canonical="$HOME/.agents/skills"
+
+  if [ -L "$link" ]; then
+    ln -snf "$canonical" "$link"
+    printf "[agent-prompts] refreshed symlink %s -> %s\n" "$link" "$canonical"
+    return
+  fi
+  if [ ! -e "$link" ]; then
+    mkdir -p "$(dirname "$link")"
+    ln -s "$canonical" "$link"
+    printf "[agent-prompts] linked %s -> %s\n" "$link" "$canonical"
+    return
+  fi
+
+  # Real directory present — migrate contents before converting to symlink.
+  local agent_name backup_root
+  agent_name="$(basename "$(dirname "$link")")"
+  backup_root="$HOME/.agents/skills-migration-backup/${agent_name#.}-$(date +%Y%m%d-%H%M%S)"
+
+  shopt -s nullglob dotglob
+  local entry name
+  for entry in "$link"/*; do
+    name="$(basename "$entry")"
+    case "$name" in .|..) continue ;; esac
+
+    if [ -L "$entry" ]; then
+      # Stale per-skill symlink (skills CLI managed) — already in canonical.
+      rm "$entry"
+    elif [ -d "$entry" ] && [ -f "$entry/SKILL.md" ] && [ ! -e "$canonical/$name" ]; then
+      mv "$entry" "$canonical/"
+      printf "[agent-prompts] adopted %s/%s into canonical\n" "$agent_name" "$name"
+    else
+      mkdir -p "$backup_root"
+      mv "$entry" "$backup_root/"
+      printf "[agent-prompts] backed up %s/%s -> %s\n" "$agent_name" "$name" "$backup_root"
+    fi
+  done
+  shopt -u nullglob dotglob
+
+  rmdir "$link" 2>/dev/null || rm -rf "$link"
+  ln -s "$canonical" "$link"
+  printf "[agent-prompts] linked %s -> %s\n" "$link" "$canonical"
+}
+
+migrate_skills_dir_to_link "$HOME/.claude/skills"
+migrate_skills_dir_to_link "$HOME/.codex/skills"
+migrate_skills_dir_to_link "$HOME/.gemini/skills"
+migrate_skills_dir_to_link "$HOME/.coder/skills"
 
 printf "[agent-prompts] Done.\n"

--- a/workspace-templates/project-workspace/main.tf
+++ b/workspace-templates/project-workspace/main.tf
@@ -225,6 +225,15 @@ resource "coder_agent" "main" {
     GIT_AUTHOR_EMAIL    = local.git_author_email
     GIT_COMMITTER_NAME  = local.git_author_name
     GIT_COMMITTER_EMAIL = local.git_author_email
+
+    # Coder Agents (chatd) defaults SkillsDirs to `.agents/skills` resolved
+    # relative to this agent's `dir` (the project) — so the user-level
+    # canonical catalog at ~/.agents/skills is invisible to it without an
+    # override. Comma-separated list lets us keep both: user-global skills
+    # (where the `skills` CLI installs and 11-agent-prompts.sh symlinks the
+    # other agents to) AND project-local skills (default Coder Agents
+    # convention, useful for repo-specific skills checked into git).
+    CODER_AGENT_EXP_SKILLS_DIRS = "~/.agents/skills,.agents/skills"
   }
 
   dynamic "metadata" {


### PR DESCRIPTION
## Summary
- Make `~/.agents/skills` the single canonical skill catalog (where the `skills` npm CLI installs natively + persistent across workspaces via the `/home/ubuntu/secrets/.agents` host bind mount).
- Convert `~/.claude/skills`, `~/.codex/skills`, `~/.gemini/skills`, and `~/.coder/skills` into folder-level symlinks to the canonical. Install a skill once → all four agents see it.
- Idempotent first-run migration in `11-agent-prompts.sh` adopts orphan skills into the canonical (real subdirs with `SKILL.md` not already there) and backs up everything else (loose files, duplicate skill dirs, agent-specific subfolders like Codex's `.system/`) under `~/.agents/skills-migration-backup/<agent>-<ts>/`.
- Coder Agents (`chatd`) defaults `SkillsDir` to `.agents/skills` resolved relative to the project dir — `~/.agents/skills` is invisible without an override. Added `CODER_AGENT_EXP_SKILLS_DIRS=~/.agents/skills,.agents/skills` to the `coder_agent` env in `project-workspace/main.tf` so chatd reads user-global skills AND project-local skills (the upstream default convention, useful for repo-checked-in skills).

## Trade-off
Loses the `skills` CLI's `-a <agent>` per-agent selectivity — every install is now global to all four agents. This matches the user's stated goal ("rolling single folder ... symlinked out to the provider specific folders") and removes the existing fan-out drift.

## Test plan
- [x] Sandbox-tested migration: dry HOME with mixed content (real-dir skill, per-skill symlink, duplicate-of-canonical, loose `.md`, Codex `.system/`, missing `~/.coder/skills`). All cases handled correctly; canonical ends with all unique skills, backups preserve everything that wasn't adopted, all four `<agent>/skills` paths end as symlinks to canonical. Re-running the script is a no-op.
- [ ] Verify in a freshly recreated workspace that `~/.coder/skills`, `~/.claude/skills`, `~/.codex/skills`, `~/.gemini/skills` all resolve to `~/.agents/skills`.
- [ ] Verify Coder Agents picks up user-global skills (open chat in workspace, call a skill installed via `skills add foo -g`, confirm it appears).
- [ ] Verify project-local `.agents/skills/` in a checked-out repo still works (default behavior preserved by the comma-separated env value).

via [HAPI](https://hapi.run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)