### PR TITLE
Persist Pencil extension auth across clients via CLI session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ base-dev (core tools, Docker, Git, GCP, AI CLIs)
 | `03-git.sh` | GitHub auth, git pull defaults, global gitignore |
 | `04-gcp.sh` | GCP project setup, secrets discovery + loading |
 | `05-rtk.sh` | RTK context optimizer hook configuration for all AI agents |
-| `06-code-server.sh` | code-server GitHub auth extension/product metadata patches |
+| `06-code-server.sh` | code-server GitHub auth extension/product metadata patches and Pencil session-cli fallback |
 | `07-vscode-themes.sh` | Installs baked `.vsix` themes from `shared-assets/vscode-themes/` into both code-server and VS Code Web |
 | `08-hapi.sh` | HAPI runner + agent session |
 | `09-shell-helpers.sh` | LazyVim, gitquick, template helpers, excalidraw |

--- a/workspace-images/base-dev/init.d/06-code-server.sh
+++ b/workspace-images/base-dev/init.d/06-code-server.sh
@@ -125,5 +125,58 @@ console.log('patched');
 NODE
 }
 
+# --- Pencil extension session fallback to CLI session file ---
+# code-server stores extension globalState in browser IndexedDB rather than on
+# disk, so the Pencil extension's session is per-browser. Pencil's CLI keeps a
+# server-side session at ~/.pencil/session-cli.json with the same shape the
+# extension's getSession() returns. Patch the extension's getSession() so it
+# falls back to that file only when both globalState entries are empty. All
+# other extension paths (setSession, signOut, lastOnlineAt, etc.) are
+# unaffected. "pencil logout" remains the way to globally sign out.
+patch_code_server_pencil_session_fallback() {
+  local extension_dir bundle_js
+  extension_dir="$(ls -1d /home/coder/.local/share/code-server/extensions/highagency.pencildev-*-universal 2>/dev/null | sort | tail -1 || true)"
+  if [ -z "$extension_dir" ] || [ ! -d "$extension_dir" ]; then
+    log "Pencil extension not installed; skipping session fallback patch"
+    return 0
+  fi
+
+  bundle_js="$(ls -1 "$extension_dir"/out/main-*.js 2>/dev/null | grep -v '\.map$' | head -1 || true)"
+  if [ -z "$bundle_js" ] || [ ! -f "$bundle_js" ]; then
+    log "Pencil extension main bundle not found under $extension_dir/out; skipping patch"
+    return 0
+  fi
+
+  BUNDLE_JS="$bundle_js" node <<'NODE'
+const fs = require('fs');
+
+const file = process.env.BUNDLE_JS;
+let source = fs.readFileSync(file, 'utf8');
+
+const originalGetSession = 'getSession(){const e=this.context.globalState.get(this.sessionKey);if(e!=null&&e.email&&(e!=null&&e.token))return{email:e.email,token:e.token};const r=this.context.globalState.get(this.legacySessionKey);if(r!=null&&r.email&&(r!=null&&r.licenseToken))return{email:r.email,token:r.licenseToken}}';
+
+const patchedGetSession = 'getSession(){const e=this.context.globalState.get(this.sessionKey);if(e!=null&&e.email&&(e!=null&&e.token))return{email:e.email,token:e.token};const r=this.context.globalState.get(this.legacySessionKey);if(r!=null&&r.email&&(r!=null&&r.licenseToken))return{email:r.email,token:r.licenseToken};try{const _p=require("path"),_o=require("os"),_f=require("fs");const _s=JSON.parse(_f.readFileSync(_p.join(_o.homedir(),".pencil","session-cli.json"),"utf8"));if(_s&&_s.email&&_s.token)return{email:_s.email,token:_s.token}}catch{}}';
+
+if (source.includes(patchedGetSession)) {
+  console.log('already patched');
+  process.exit(0);
+}
+
+if (!source.includes(originalGetSession)) {
+  console.error(`Could not find expected Pencil getSession() implementation in ${file}`);
+  process.exit(1);
+}
+
+source = source.replace(originalGetSession, patchedGetSession);
+
+if (!fs.existsSync(`${file}.cli-session-fallback.bak`)) {
+  fs.copyFileSync(file, `${file}.cli-session-fallback.bak`);
+}
+fs.writeFileSync(file, source);
+console.log('patched');
+NODE
+}
+
 patch_code_server_github_auth_extension || log "warning: failed to patch GitHub authentication extension"
 patch_code_server_trusted_github_extensions || log "warning: failed to patch code-server trusted GitHub extensions"
+patch_code_server_pencil_session_fallback || log "warning: failed to patch Pencil session fallback"


### PR DESCRIPTION
## Summary
Patch the Pencil VS Code extension's installed bundle so its `getSession()` falls back to `~/.pencil/session-cli.json` only when both globalState entries are empty. No other extension behavior is changed.

## Why
The Pencil extension stores its session in `context.globalState`. In code-server, globalState is forwarded to the browser and persisted in **browser IndexedDB** rather than on disk on the server (no `state.vscdb` is created server-side). Each new browser/device starts with empty globalState, so the user is forced to re-activate Pencil per client.

The Pencil CLI keeps a server-side session at `~/.pencil/session-cli.json` with the same `{ email, token }` shape that the extension's `getSession()` returns. Logging in with `pencil login` once is enough; the file persists across rebuilds and is the same for every client hitting the workspace.

## What it changes
- New init function `patch_code_server_pencil_session_fallback` in `workspace-images/base-dev/init.d/06-code-server.sh`.
- Locates the user-installed Pencil extension at `~/.local/share/code-server/extensions/highagency.pencildev-*-universal/out/main-*.js`, then performs a literal-string replacement of the minified `getSession()` body, adding a third fallback that reads the CLI session file.
- Backs up the original bundle next to itself (`*.cli-session-fallback.bak`) and is idempotent (skip on "already patched", skip on missing extension or bundle).
- All other Pencil paths (`setSession`, `signOut`, `setLastOnlineAt`, etc.) are untouched.

## Behavior summary
| Case | Result |
| --- | --- |
| Empty globalState + valid CLI session file | Returns CLI session (no activation prompt) |
| globalState has session | Returns stored session (no behavior change) |
| globalState has only legacy `licenseToken` | Returns legacy session (no behavior change) |
| Empty globalState + missing CLI file | Returns undefined (Pencil prompts to activate, same as before) |
| Empty globalState + malformed CLI file | Returns undefined (graceful) |

## Caveat
Because the CLI session is the source of truth on the server, the extension's "Sign Out" command only signs out the current browser. To sign out globally across browsers, run `pencil logout` (which removes `session-cli.json`).

## Validation
- `bash -n workspace-images/base-dev/init.d/06-code-server.sh`
- `git diff --check`
- Applied the patch to a copy of the installed `highagency.pencildev-0.6.49` bundle and ran `node --check`.
- Functional test invoking the patched `getSession` under five conditions (empty globalState + valid file, stored session present, legacy session present, missing file, malformed file). All five behave as expected.