### PR TITLE
Fix Coder agent workspace naming rules

### DIFF
--- a/coder-agents-config/system-prompt.txt
+++ b/coder-agents-config/system-prompt.txt
@@ -14,13 +14,16 @@ include_default_system_prompt: true
 - If a Coder workspace is already attached to this chat, work in that workspace. Do not create a new one.
 - If no workspace is attached and the task requires one:
   1. Use the `github` MCP server to identify the repo the user is referring to (search by name, description, or whatever context the user gave). Ask only if the match is genuinely ambiguous.
-  2. Check existing workspaces for one named `{Project-Name}-Agents` (PascalCase project name + `-Agents` suffix). If it exists, use it.
-  3. Otherwise create a workspace from the `project-workspace` template with parameters:
-     - `workspace_mode = "agent"`
+  2. Derive the base workspace name from the project/repo name: PascalCase it and replace any spaces with `-` (workspace names cannot contain spaces).
+  3. Determine the workspace mode the user wants (`agent` or `self`). Default to `agent` if not specified.
+  4. For `agent` mode, append `-Agents` to the base name (e.g. `My-Project-Agents`). For `self` mode, use the base name as-is (e.g. `My-Project`).
+  5. Check existing workspaces for that computed name. If it exists, use it.
+  6. Otherwise create a workspace from the `project-workspace` template with parameters:
+     - `workspace_mode` = `"agent"` or `"self"` per above
      - `is_existing_project = "existing"` and `repo_name = <bare repo name, no owner>` for an existing GitHub repo
      - or `is_existing_project = "new"` and `new_project_type` ∈ {`base`, `python`, `nextjs`, `cpp`, `fullstack`} matching the stack the user described, plus `project_name`
      - `gcp_project_name` — leave empty unless the user mentions GCP or you've confirmed the project uses GCP secrets
-     - Workspace name = `{Project-Name}-Agents`
-  4. Wait for it to start, then continue the task in it.
+     - Workspace name = computed name from step 4
+  7. Wait for it to start, then continue the task in it.
 
 Use the `project-workspace` template by default; do not create from any other template unless the user explicitly asks.


### PR DESCRIPTION
## Summary

Updates the workspace creation policy in `coder-agents-config/system-prompt.txt`:

- **Self mode**: workspaces created with `workspace_mode = "self"` use the bare project name (e.g. `My-Project`) — no `-Agents` suffix.
- **Agent mode**: still appends `-Agents` (e.g. `My-Project-Agents`) as before.
- **Spaces → dashes**: project/repo names with spaces are converted (e.g. `My Project` → `My-Project`) since Coder workspace names cannot contain spaces.

The lookup step now uses the correctly computed name for both the existence check and the create call.