### PR TITLE
Fix GitHub auth grant-access dialog by patching workbench bundles directly

### DIFF
--- a/workspace-images/base-dev/init.d/06-code-server.sh
+++ b/workspace-images/base-dev/init.d/06-code-server.sh
@@ -184,6 +184,50 @@ console.log('patched');
 NODE
 }
 
+# --- Patch browser workbench bundles for GitHub auth trust ---
+# The trustedExtensionAuthAccess array is baked into the browser-side workbench
+# bundles at build time. Patching product.json only affects the server-side
+# IProductService; the browser IProductService (where isAccessAllowed() runs)
+# reads from the hardcoded bundle value. We do a literal string append in the
+# two browser-served bundles so the grant-access dialog never shows for
+# GitHub Actions and GitLens.
+patch_code_server_workbench_bundle_auth_trust() {
+  local install_root
+  if ! install_root="$(code_server_install_root)"; then
+    log "code-server binary not found; skipping workbench bundle auth trust patch"
+    return 0
+  fi
+
+  local anchor='"github.copilot","github.copilot-chat"]'
+  local patched='"github.copilot","github.copilot-chat","github.vscode-github-actions","eamodio.gitlens"]'
+
+  local bundles=(
+    "$install_root/lib/vscode/out/vs/code/browser/workbench/workbench.js"
+    "$install_root/lib/vscode/out/vs/workbench/workbench.web.main.internal.js"
+  )
+
+  local patched_any=0
+  for bundle in "${bundles[@]}"; do
+    [ -f "$bundle" ] || continue
+    if grep -qF "$patched" "$bundle"; then
+      log "$(basename "$bundle") already patched; skipping"
+      continue
+    fi
+    if ! grep -qF "$anchor" "$bundle"; then
+      log "warning: expected trustedExtensionAuthAccess anchor not found in $(basename "$bundle"); skipping"
+      continue
+    fi
+    if [ ! -f "${bundle}.trusted-auth-patch.bak" ]; then
+      cp "$bundle" "${bundle}.trusted-auth-patch.bak"
+    fi
+    sed -i 's|"github\.copilot","github\.copilot-chat"\]|"github.copilot","github.copilot-chat","github.vscode-github-actions","eamodio.gitlens"]|g' "$bundle"
+    log "patched $(basename "$bundle") trustedExtensionAuthAccess"
+    patched_any=1
+  done
+  [ "$patched_any" -eq 1 ] || log "no workbench bundles needed patching"
+}
+
 patch_code_server_github_auth_extension || log "warning: failed to patch GitHub authentication extension"
 patch_code_server_trusted_github_extensions || log "warning: failed to patch code-server trusted GitHub extensions"
+patch_code_server_workbench_bundle_auth_trust || log "warning: failed to patch workbench bundle auth trust"
 patch_code_server_pencil_session_fallback || log "warning: failed to patch Pencil session fallback"


### PR DESCRIPTION
## Root cause

The "Grant access to GitHub Actions / GitLens" dialog was persisting despite the existing `product.json` patch (PR #28) because `trustedExtensionAuthAccess` is **baked into the browser-side workbench bundles at compile time**.

The browser `IProductService` (where `isAccessAllowed()` runs and the dialog decision is made) reads from this hardcoded bundle value — not from the server-side `product.json`. The previous patch correctly updated `product.json` for the server-side service but had no effect on the browser-side check.

In the bundle, `isAccessAllowed` is implemented as:
```js
isAccessAllowed(providerId, accountName, extensionId) {
  let n = this._productService.trustedExtensionAuthAccess, r = gi.toKey(extensionId);
  if (Array.isArray(n)) { if (n.includes(r)) return true; }
  else if (n?.[providerId]?.includes(r)) return true;
  // else check stored per-user permissions → shows dialog if none
}
```
The bundle ships with `trustedExtensionAuthAccess: ["vscode.git","vscode.github","github.vscode-pull-request-github","github.copilot","github.copilot-chat"]` — neither `github.vscode-github-actions` nor `eamodio.gitlens` are in it.

## Fix

New `patch_code_server_workbench_bundle_auth_trust()` function in `06-code-server.sh` that patches the two browser-served bundles:
- `out/vs/code/browser/workbench/workbench.js`
- `out/vs/workbench/workbench.web.main.internal.js`

It appends `"github.vscode-github-actions"` and `"eamodio.gitlens"` to the hardcoded array via a literal `sed` string substitution. Backup, idempotency guard, and anchor-missing guard all included.

## Validation
- `bash -n 06-code-server.sh` passes
- Dry-run of the `sed` against the installed `workbench.js` confirms anchor found and patch applied, matching `"github.vscode-github-actions","eamodio.gitlens"]` in 2 locations (the hardcoded product constant appears twice in the bundle)