### PR TITLE
Move claude/codex usage apps from project-workspace to workspace-apps module

### DIFF
--- a/workspace-modules/workspace-apps/main.tf
+++ b/workspace-modules/workspace-apps/main.tf
@@ -149,3 +149,27 @@ module "filebrowser" {
   database_path = "/tmp/filebrowser.db"
   order         = 4
 }
+
+
+resource "coder_app" "claude_usage" {
+  count        = var.enable_apps && var.enable_claude_usage ? 1 : 0
+  agent_id     = var.agent_id
+  slug         = "claude-usage"
+  display_name = "Claude Usage"
+  icon         = "/icon/claude.svg"
+  url          = "https://claude.ai/settings/usage"
+  external     = true
+  order        = 11
+}
+
+
+resource "coder_app" "codex_usage" {
+  count        = var.enable_apps && var.enable_codex_usage ? 1 : 0
+  agent_id     = var.agent_id
+  slug         = "codex-usage"
+  display_name = "Codex Usage"
+  icon         = "/icon/openai.svg"
+  url          = "https://chatgpt.com/codex/cloud/settings/analytics#usage"
+  external     = true
+  order        = 12
+}

--- a/workspace-modules/workspace-apps/variables.tf
+++ b/workspace-modules/workspace-apps/variables.tf
@@ -45,3 +45,15 @@ variable "enable_filebrowser" {
   type        = bool
   default     = true
 }
+
+variable "enable_claude_usage" {
+  description = "Whether to create the Claude usage link app"
+  type        = bool
+  default     = true
+}
+
+variable "enable_codex_usage" {
+  description = "Whether to create the Codex usage link app"
+  type        = bool
+  default     = true
+}

--- a/workspace-templates/project-workspace/main.tf
+++ b/workspace-templates/project-workspace/main.tf
@@ -314,26 +314,3 @@ resource "coder_app" "hapi" {
   order        = 10
 }
 
-# Vendor usage dashboards — Anthropic / OpenAI publish authoritative quota
-# state (5h-window, weekly cap) only in their own UIs; no public API exists.
-# These tiles open the vendor pages in a new tab, glanceable next to the
-# Coder Agents workspace apps panel.
-resource "coder_app" "claude_usage" {
-  agent_id     = coder_agent.main.id
-  slug         = "claude-usage"
-  display_name = "Claude Usage"
-  icon         = "https://claude.ai/favicon.ico"
-  url          = "https://claude.ai/settings/usage"
-  external     = true
-  order        = 11
-}
-
-resource "coder_app" "codex_usage" {
-  agent_id     = coder_agent.main.id
-  slug         = "codex-usage"
-  display_name = "Codex Usage"
-  icon         = "https://chatgpt.com/favicon.ico"
-  url          = "https://chatgpt.com/codex/cloud/settings/analytics#usage"
-  external     = true
-  order        = 12
-}


### PR DESCRIPTION
Properly moves the Claude and Codex usage link apps into the shared `workspace-apps` module so all templates that use the module get them automatically.\n\n**Commit 1** — Removes inline `coder_app.claude_usage` and `coder_app.codex_usage` from `project-workspace/main.tf` (along with the now-orphaned comment block).\n\n**Commit 2** — Adds them to `workspace-modules/workspace-apps/main.tf` with:\n- Per-app toggle flags `enable_claude_usage` and `enable_codex_usage` (both default `true`)\n- Built-in Coder icons: `/icon/claude.svg` and `/icon/openai.svg`\n- Same `order` values (11, 12) and slugs (`claude-usage`, `codex-usage`)