### PR TITLE
Prioritize usage apps in workspace preview

### DIFF
--- a/workspace-modules/workspace-apps/main.tf
+++ b/workspace-modules/workspace-apps/main.tf
@@ -17,7 +17,7 @@ module "vscode-desktop" {
   coder_app_icon         = "/icon/desktop.svg"
   coder_app_slug         = "vscode"
   coder_app_display_name = "VS Code Desktop"
-  coder_app_order        = 4
+  coder_app_order        = 5
 
   folder   = "/workspaces/${var.project_name}"
   protocol = "vscode"
@@ -29,7 +29,7 @@ module "cursor" {
   version  = "1.2.1"
   agent_id = var.agent_id
   folder   = "/workspaces/${var.project_name}"
-  order    = 5
+  order    = 6
 }
 
 
@@ -150,7 +150,7 @@ module "filebrowser" {
   agent_id      = var.agent_id
   folder        = "/workspaces/${var.project_name}"
   database_path = "/tmp/filebrowser.db"
-  order         = 1
+  order         = 4
 }
 
 
@@ -162,7 +162,7 @@ resource "coder_app" "claude_usage" {
   icon         = "/icon/claude.svg"
   url          = "https://claude.ai/settings/usage"
   external     = true
-  order        = 2
+  order        = 1
 }
 
 
@@ -174,5 +174,5 @@ resource "coder_app" "codex_usage" {
   icon         = "/icon/openai.svg"
   url          = "https://chatgpt.com/codex/cloud/settings/analytics#usage"
   external     = true
-  order        = 3
+  order        = 2
 }


### PR DESCRIPTION
## Summary
- Reorders workspace apps so the first custom app previews are code-server, Claude Usage, and Codex Usage
- Moves File Browser after the usage links while keeping VS Code Desktop and Cursor Desktop last
- Leaves native Coder Terminal enabled and unchanged

## Verification
- terraform fmt -check -recursive workspace-modules/workspace-apps
- terraform init -backend=false && terraform validate in workspace-modules/workspace-apps