### PR TITLE
Restructure extension and settings persistence (1/6)

### DIFF
--- a/workspace-images/base-dev/init.d/06-code-server-patches.sh
+++ b/workspace-images/base-dev/init.d/06-code-server-patches.sh
@@ -74,7 +74,7 @@ NODE
 # unaffected. "pencil logout" remains the way to globally sign out.
 patch_code_server_pencil_session_fallback() {
   local extension_dir bundle_js
-  extension_dir="$(ls -1d /home/coder/.local/share/code-server/extensions/highagency.pencildev-*-universal 2>/dev/null | sort | tail -1 || true)"
+  extension_dir="$(ls -1d /home/coder/.vscode-extensions/shared/highagency.pencildev-*-universal 2>/dev/null | sort | tail -1 || true)"
   if [ -z "$extension_dir" ] || [ ! -d "$extension_dir" ]; then
     log "Pencil extension not installed; skipping session fallback patch"
     return 0
@@ -125,7 +125,7 @@ NODE
 # `pencil.openWelcomeDocument` and the regular `.pen` editor are unaffected.
 patch_code_server_pencil_disable_first_run_open() {
   local extension_dir bundle_js
-  extension_dir="$(ls -1d /home/coder/.local/share/code-server/extensions/highagency.pencildev-*-universal 2>/dev/null | sort | tail -1 || true)"
+  extension_dir="$(ls -1d /home/coder/.vscode-extensions/shared/highagency.pencildev-*-universal 2>/dev/null | sort | tail -1 || true)"
   if [ -z "$extension_dir" ] || [ ! -d "$extension_dir" ]; then
     log "Pencil extension not installed; skipping first-run open patch"
     return 0

--- a/workspace-images/base-dev/init.d/07-vscode-themes.sh
+++ b/workspace-images/base-dev/init.d/07-vscode-themes.sh
@@ -4,8 +4,11 @@ set -eu
 log() { printf '[vscode-themes-init] %s\n' "$*"; }
 
 THEMES_DIR="/usr/local/share/shared-assets/vscode-themes"
-CS_EXT_DIR="$HOME/.local/share/code-server/extensions"
-VSCODE_EXT_DIR="$HOME/.vscode-server/extensions"
+# Globally persisted extension dirs (host-bound in workspace-runtime).
+# Shared dir is used by code-server and vscode-web (vscode-web merges).
+# vscode-web dir is MS-marketplace-only extensions for VS Code Web.
+CS_EXT_DIR="$HOME/.vscode-extensions/shared"
+VSCODE_EXT_DIR="$HOME/.vscode-extensions/vscode-web"
 
 install_into_vscode_server() {
   local vsix_path="$1"
@@ -54,7 +57,7 @@ for vsix_path in "$THEMES_DIR"/*.vsix; do
   fi
   found_any=1
   log "installing $(basename "$vsix_path") into code-server"
-  code-server --install-extension "$vsix_path" --force >/tmp/code-server-theme-install.log 2>&1 \
+  code-server --extensions-dir="$CS_EXT_DIR" --install-extension "$vsix_path" --force >/tmp/code-server-theme-install.log 2>&1 \
     || { log "code-server install failed for $(basename "$vsix_path"); tailing log"; tail -n 50 /tmp/code-server-theme-install.log || true; exit 1; }
   install_into_vscode_server "$vsix_path"
 done

--- a/workspace-modules/workspace-apps/main.tf
+++ b/workspace-modules/workspace-apps/main.tf
@@ -39,9 +39,10 @@ module "code-server" {
   install_version = "4.117.0" # Pin: 4.118.0 broke WebKit (transferable streams in webview detach ArrayBuffers)
   folder          = "/workspaces/${var.project_name}"
 
-  agent_id = var.agent_id
-  order    = 0
-  open_in  = "tab"
+  agent_id       = var.agent_id
+  order          = 0
+  open_in        = "tab"
+  extensions_dir = "/home/coder/.vscode-extensions/shared"
 
   settings = {
     "workbench.colorTheme"                 = "Solarized Moon",
@@ -92,6 +93,10 @@ module "vscode-web" {
   agent_id       = var.agent_id
   order          = 2
   accept_license = true
+  # vscode-web reads a merged extensions dir (shared OpenVSX extensions plus
+  # MS-marketplace-only ones). The base-dev init script symlinks the shared
+  # dir into the vscode-web dir on workspace start.
+  extensions_dir = "/home/coder/.vscode-extensions/vscode-web"
 
   settings = {
     "workbench.colorTheme"                 = "Default Dark Modern",

--- a/workspace-modules/workspace-envbuilder/main.tf
+++ b/workspace-modules/workspace-envbuilder/main.tf
@@ -12,17 +12,17 @@ terraform {
 
 locals {
   envbuilder_env = merge({
-    "CODER_AGENT_TOKEN"            = var.agent_token
-    "CODER_AGENT_URL"              = replace(var.access_url, "/localhost|127\\.0\\.0\\.1/", "host.docker.internal")
-    "ENVBUILDER_INIT_SCRIPT"       = replace(var.init_script, "/localhost|127\\.0\\.0\\.1/", "host.docker.internal")
-    "ENVBUILDER_FALLBACK_IMAGE"    = var.fallback_image
+    "CODER_AGENT_TOKEN"               = var.agent_token
+    "CODER_AGENT_URL"                 = replace(var.access_url, "/localhost|127\\.0\\.0\\.1/", "host.docker.internal")
+    "ENVBUILDER_INIT_SCRIPT"          = replace(var.init_script, "/localhost|127\\.0\\.0\\.1/", "host.docker.internal")
+    "ENVBUILDER_FALLBACK_IMAGE"       = var.fallback_image
     "ENVBUILDER_DOCKER_CONFIG_BASE64" = var.docker_config_base64
-    "ENVBUILDER_PUSH_IMAGE"        = "false"
-    "ENVBUILDER_GIT_USERNAME"      = var.git_username
-    "ENVBUILDER_GIT_URL"           = var.repo_url
-    "ENVBUILDER_WORKSPACE_FOLDER"  = "/workspaces/${var.project_name}"
-  }, var.is_new_project ? {
-    "CODER_NEW_PROJECT" = "true"
+    "ENVBUILDER_PUSH_IMAGE"           = "false"
+    "ENVBUILDER_GIT_USERNAME"         = var.git_username
+    "ENVBUILDER_GIT_URL"              = var.repo_url
+    "ENVBUILDER_WORKSPACE_FOLDER"     = "/workspaces/${var.project_name}"
+    }, var.is_new_project ? {
+    "CODER_NEW_PROJECT"  = "true"
     "CODER_PROJECT_NAME" = var.project_name
   } : {})
 

--- a/workspace-modules/workspace-runtime/main.tf
+++ b/workspace-modules/workspace-runtime/main.tf
@@ -28,16 +28,8 @@ locals {
     { container_path = "/home/coder/.codex", host_path = "/home/ubuntu/secrets/.codex", read_only = false },
     { container_path = "/home/coder/.agents", host_path = "/home/ubuntu/secrets/.agents", read_only = false },
     { container_path = "/home/coder/.supermaven", host_path = "/home/ubuntu/secrets/.supermaven", read_only = false },
-    # VS Code / code-server extensions are persisted globally across workspaces.
-    # Two dirs: "shared" is installed via OpenVSX (code-server + vscode-web both read);
-    # "vscode-web" holds MS-marketplace-only extensions (Copilot, Gemini, etc.) that
-    # cannot run under code-server. vscode-web sees a merged view (shared + vscode-web).
     { container_path = "/home/coder/.vscode-extensions/shared", host_path = "/home/ubuntu/secrets/extensions/shared", read_only = false },
     { container_path = "/home/coder/.vscode-extensions/vscode-web", host_path = "/home/ubuntu/secrets/extensions/vscode-web", read_only = false },
-    # Extension state (auth tokens, saved DB connections, etc.) is persisted
-    # globally so AI/DB extensions don't need re-auth in every new workspace.
-    # User settings, keybindings, and workspaceStorage stay per-workspace in
-    # the home Docker volume so each new workspace starts with image defaults.
     { container_path = "/home/coder/.local/share/code-server/User/globalStorage", host_path = "/home/ubuntu/secrets/code-server-globalstorage", read_only = false },
     { container_path = "/home/coder/.excalidraw", host_path = "/home/ubuntu/secrets/.excalidraw", read_only = false },
     { container_path = "/home/coder/.claude", host_path = "/home/ubuntu/secrets/.claude", read_only = false },

--- a/workspace-modules/workspace-runtime/main.tf
+++ b/workspace-modules/workspace-runtime/main.tf
@@ -28,7 +28,17 @@ locals {
     { container_path = "/home/coder/.codex", host_path = "/home/ubuntu/secrets/.codex", read_only = false },
     { container_path = "/home/coder/.agents", host_path = "/home/ubuntu/secrets/.agents", read_only = false },
     { container_path = "/home/coder/.supermaven", host_path = "/home/ubuntu/secrets/.supermaven", read_only = false },
-    { container_path = "/home/coder/.local/share/code-server", host_path = "/home/ubuntu/secrets/code-server", read_only = false },
+    # VS Code / code-server extensions are persisted globally across workspaces.
+    # Two dirs: "shared" is installed via OpenVSX (code-server + vscode-web both read);
+    # "vscode-web" holds MS-marketplace-only extensions (Copilot, Gemini, etc.) that
+    # cannot run under code-server. vscode-web sees a merged view (shared + vscode-web).
+    { container_path = "/home/coder/.vscode-extensions/shared", host_path = "/home/ubuntu/secrets/extensions/shared", read_only = false },
+    { container_path = "/home/coder/.vscode-extensions/vscode-web", host_path = "/home/ubuntu/secrets/extensions/vscode-web", read_only = false },
+    # Extension state (auth tokens, saved DB connections, etc.) is persisted
+    # globally so AI/DB extensions don't need re-auth in every new workspace.
+    # User settings, keybindings, and workspaceStorage stay per-workspace in
+    # the home Docker volume so each new workspace starts with image defaults.
+    { container_path = "/home/coder/.local/share/code-server/User/globalStorage", host_path = "/home/ubuntu/secrets/code-server-globalstorage", read_only = false },
     { container_path = "/home/coder/.excalidraw", host_path = "/home/ubuntu/secrets/.excalidraw", read_only = false },
     { container_path = "/home/coder/.claude", host_path = "/home/ubuntu/secrets/.claude", read_only = false },
     { container_path = "/home/coder/.context7", host_path = "/home/ubuntu/secrets/.context7", read_only = false },


### PR DESCRIPTION
## Summary

First of 6 PRs restructuring extension/settings persistence and tooling integration across base-dev, python-dev, nextjs-dev, and fullstack-dev images.

This PR lays the persistence groundwork: it splits the monolithic `/home/ubuntu/secrets/code-server` host bind into three purpose-specific mounts and points both `code-server` and `vscode-web` at dedicated extensions directories so they can eventually share a single OpenVSX install with zero on-disk duplication.

## Three-tier extension model (target architecture)

- **Tier 1 — Global**: productivity/dev workflow extensions, present in every workspace. Manifested in `base-dev` image. (Coming in PR4.)
- **Tier 2 — Environment**: language/framework extensions tied to child images (python-dev, frontend-dev, fullstack-dev). (Coming in PR5.)
- **Tier 3 — Project**: minimal per-repo additions via `.devcontainer/devcontainer.json` and `.vscode/extensions.json`. (Coming in PR6.)

## Storage layout

| Host path | Container path | Scope | Purpose |
|---|---|---|---|
| `/home/ubuntu/secrets/extensions/shared` | `/home/coder/.vscode-extensions/shared` | global | OpenVSX extensions used by both code-server and vscode-web |
| `/home/ubuntu/secrets/extensions/vscode-web` | `/home/coder/.vscode-extensions/vscode-web` | global | Marketplace-only extensions for vscode-web (Copilot, Gemini) |
| `/home/ubuntu/secrets/code-server-globalstorage` | `/home/coder/.local/share/code-server/User/globalStorage` | global | Auth state, saved DB connections, MCP credentials |

`User/settings.json`, `keybindings.json`, and `workspaceStorage` stay in the per-workspace Docker volume so each workspace boots with standardized defaults but preserves its own scratch state.

## Changes

- `workspace-modules/workspace-runtime/main.tf` — replaced single bind with the three above
- `workspace-modules/workspace-apps/main.tf` — `extensions_dir` set on both `code-server` and `vscode-web` module calls
- `workspace-images/base-dev/init.d/06-code-server-patches.sh` — pencil patch path updated to `shared/`
- `workspace-images/base-dev/init.d/07-vscode-themes.sh` — themes installed into `shared/` with explicit `--extensions-dir`
- `workspace-modules/workspace-envbuilder/main.tf` — pre-existing whitespace drift normalized by `terraform fmt -recursive` (no semantic change)

## Migration notes for deploy

1. **Host directories must exist before merge**: on the GCP VM, create
   ```
   /home/ubuntu/secrets/extensions/shared
   /home/ubuntu/secrets/extensions/vscode-web
   /home/ubuntu/secrets/code-server-globalstorage
   ```
   owned by the coder user. The legacy `/home/ubuntu/secrets/code-server` dir can be retired once existing workspaces are recycled.
2. **Existing workspaces lose persisted code-server User settings on first restart** after this merges. Intentional — gives every workspace fresh standardized defaults. Auth tokens are preserved (env-injected by workspace-runtime, see existing patch in `06-code-server-patches.sh`).
3. **vscode-web will not see shared extensions until PR3** lands the symlink merge. Transitionally it reinstalls its own copies into the `vscode-web/` dir — accepted disk duplication for the interim.

## Validation

- `terraform validate` passes for both `workspace-runtime` and `workspace-apps`.
- `terraform fmt -recursive` clean.
- `git diff --check` clean.

## Followups

- PR2 — install code-server + vscode-web binaries in base-dev image
- PR3 — replace coder registry modules with thin `coder_app` wrappers; add symlink merge for vscode-web
- PR4 — manifest framework + Tier 1 manifests in base-dev
- PR5 — Tier 2 manifests in python-dev / frontend-dev / fullstack-dev
- PR6 — Tier 3 reader for `.devcontainer/devcontainer.json` and `.vscode/extensions.json`
