### PR TITLE
Bake code-server and vscode-web into base-dev image (2/6)

### DIFF
--- a/workspace-images/base-dev/Dockerfile
+++ b/workspace-images/base-dev/Dockerfile
@@ -90,9 +90,6 @@ RUN SIGNOZ_VERSION=0.2.1 \
  && rm -rf signoz-mcp.tar.gz "signoz-mcp-server_linux_${ARCH}"
 
 # code-server — OpenVSX-based browser editor served on the code-server Coder app.
-# Pinned to 4.117.0; 4.118.0 broke WebKit and is not safe to roll forward yet.
-# Installed once into the image so the workspace boot script just launches it
-# (replaces the old registry.coder.com/coder/code-server module download path).
 ENV CODE_SERVER_VERSION=4.117.0
 ENV CODE_SERVER_PREFIX=/opt/code-server
 RUN curl -fsSL https://code-server.dev/install.sh \
@@ -101,9 +98,6 @@ RUN curl -fsSL https://code-server.dev/install.sh \
  && chown -R coder:coder "${CODE_SERVER_PREFIX}"
 
 # vscode-web — Microsoft VS Code server bundle, used by the vscode-web Coder app.
-# Latest stable commit at image build time is baked in (image rebuilds pick up
-# newer commits). Installed under a separate prefix so its 'code-server' binary
-# does not collide with the OpenVSX code-server above.
 ENV VSCODE_WEB_PREFIX=/opt/vscode-web
 RUN ARCH=$(uname -m) \
  && case "$ARCH" in x86_64) ARCH=x64 ;; aarch64) ARCH=arm64 ;; *) echo "Unsupported arch $ARCH" >&2; exit 1 ;; esac \

--- a/workspace-images/base-dev/Dockerfile
+++ b/workspace-images/base-dev/Dockerfile
@@ -89,6 +89,32 @@ RUN SIGNOZ_VERSION=0.2.1 \
  && install "signoz-mcp-server_linux_${ARCH}/bin/signoz-mcp-server" -D -t /usr/local/bin/ \
  && rm -rf signoz-mcp.tar.gz "signoz-mcp-server_linux_${ARCH}"
 
+# code-server — OpenVSX-based browser editor served on the code-server Coder app.
+# Pinned to 4.117.0; 4.118.0 broke WebKit and is not safe to roll forward yet.
+# Installed once into the image so the workspace boot script just launches it
+# (replaces the old registry.coder.com/coder/code-server module download path).
+ENV CODE_SERVER_VERSION=4.117.0
+ENV CODE_SERVER_PREFIX=/opt/code-server
+RUN curl -fsSL https://code-server.dev/install.sh \
+      | sh -s -- --method=standalone --prefix="${CODE_SERVER_PREFIX}" --version="${CODE_SERVER_VERSION}" \
+ && ln -sf "${CODE_SERVER_PREFIX}/bin/code-server" /usr/local/bin/code-server \
+ && chown -R coder:coder "${CODE_SERVER_PREFIX}"
+
+# vscode-web — Microsoft VS Code server bundle, used by the vscode-web Coder app.
+# Latest stable commit at image build time is baked in (image rebuilds pick up
+# newer commits). Installed under a separate prefix so its 'code-server' binary
+# does not collide with the OpenVSX code-server above.
+ENV VSCODE_WEB_PREFIX=/opt/vscode-web
+RUN ARCH=$(uname -m) \
+ && case "$ARCH" in x86_64) ARCH=x64 ;; aarch64) ARCH=arm64 ;; *) echo "Unsupported arch $ARCH" >&2; exit 1 ;; esac \
+ && HASH=$(curl -fsSL "https://update.code.visualstudio.com/api/commits/stable/server-linux-${ARCH}-web" | cut -d '"' -f 2) \
+ && test -n "$HASH" \
+ && mkdir -p "${VSCODE_WEB_PREFIX}" \
+ && curl -fsSL "https://vscode.download.prss.microsoft.com/dbazure/download/stable/${HASH}/vscode-server-linux-${ARCH}-web.tar.gz" \
+      | tar -xz -C "${VSCODE_WEB_PREFIX}" --strip-components 1 \
+ && ln -sf "${VSCODE_WEB_PREFIX}/bin/code-server" /usr/local/bin/vscode-web \
+ && chown -R coder:coder "${VSCODE_WEB_PREFIX}"
+
 USER coder
 RUN git config --global credential.helper "store --file=/home/coder/.git-credentials" \
  && gh config set git_protocol https || true


### PR DESCRIPTION
## Summary

PR 2/6 of the extension/settings restructure. Bakes both editor server binaries into the `base-dev` image so the workspace boot path becomes "launch what is on disk" instead of fetching them on every workspace start.

```
/opt/code-server/bin/code-server   OpenVSX, pinned to 4.117.0
/opt/vscode-web/bin/code-server    Microsoft Marketplace, latest stable commit
                                    baked in at image build time
```

Symlinks `/usr/local/bin/code-server` and `/usr/local/bin/vscode-web` are added for ad-hoc CLI use; the Coder-app run scripts (replaced in PR3) invoke these by absolute prefix path so the binary-name collision between the two is irrelevant.

## Why two prefixes

Both binaries are literally named `code-server`. Separate prefixes mean the prefix dir doubles as a unique identity, and the launcher script in PR3 can pick the right binary without arg parsing tricks.

## Why pin only code-server

`4.117.0` is the last code-server release that ships a working WebKit on this base image (`4.118.0` regressed). vscode-web has no equivalent regression; tracking latest at image-build time is fine since image rebuilds are deliberate.

## Build

Triggered by `.github/workflows/build-base-dev.yaml` on push to `main`. Multi-arch (amd64, arm64) on native runners.

## Followups

- PR3 — replace the `registry.coder.com/coder/{code-server,vscode-web}` module calls with thin `coder_app` + `coder_script` wrappers; adds the shared → vscode-web extension symlink merge.
- PRs 4-6 — manifest framework, per-env Tier 2 manifests, Tier 3 reader.

Stacks on top of #37 conceptually but is independent at the file level (image change vs Terraform change).
