### PR TITLE
Thin coder_app wrappers replacing registry code-server / vscode-web modules (3/6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ node_modules/
 
 #Scrapyard
 scrapyard/
+# Terraform
+.terraform/
+.terraform.lock.hcl

--- a/workspace-modules/workspace-apps/main.tf
+++ b/workspace-modules/workspace-apps/main.tf
@@ -6,6 +6,37 @@ terraform {
   }
 }
 
+data "coder_workspace" "me" {}
+data "coder_workspace_owner" "me" {}
+
+locals {
+  # The launchers below are intentionally thin: they assume the binaries are
+  # already on disk (baked into base-dev) and that anything else editor-related
+  # — extension installs, User/Machine settings.json files, in-place patches
+  # — is the responsibility of workspace-init.d scripts in base-dev. Keep
+  # Terraform locals limited to ports, paths, and CLI flags.
+
+  # ---- code-server (OpenVSX) ----
+  code_server_port           = 13337
+  code_server_install_prefix = "/opt/code-server"
+  code_server_extensions_dir = "/home/coder/.vscode-extensions/shared"
+  code_server_log_path       = "/tmp/code-server.log"
+
+  # ---- vscode-web (Microsoft) ----
+  vscode_web_port              = 13338
+  vscode_web_install_prefix    = "/opt/vscode-web"
+  vscode_web_extensions_dir    = "/home/coder/.vscode-extensions/vscode-web"
+  vscode_web_shared_extensions = "/home/coder/.vscode-extensions/shared"
+  vscode_web_log_path          = "/tmp/vscode-web.log"
+  vscode_web_telemetry_level   = "error"
+  vscode_web_subdomain         = true
+  vscode_web_server_base_path = (
+    local.vscode_web_subdomain
+    ? ""
+    : format("/@%s/%s/apps/vscode-web/", data.coder_workspace_owner.me.name, data.coder_workspace.me.name)
+  )
+}
+
 
 module "vscode-desktop" {
   count   = var.enable_apps && var.enable_vscode_desktop ? 1 : 0
@@ -33,109 +64,88 @@ module "cursor" {
 }
 
 
-module "code-server" {
-  count           = var.enable_apps && var.enable_code_server ? 1 : 0
-  source          = "registry.coder.com/coder/code-server/coder"
-  install_version = "4.117.0" # Pin: 4.118.0 broke WebKit (transferable streams in webview detach ArrayBuffers)
-  folder          = "/workspaces/${var.project_name}"
+# code-server (OpenVSX) — thin wrapper around the binary baked into base-dev.
+# Binary is installed at /opt/code-server/bin/code-server by the image build;
+# this resource just configures and launches it. Replaces the
+# registry.coder.com/coder/code-server module so we avoid a download on each
+# workspace start. Extension installation is intentionally not handled here
+# anymore — the manifest framework introduced in the next PR populates the
+# shared extensions dir at image build / first boot, and persisted extensions
+# survive across restarts via the host-bound shared mount.
+resource "coder_script" "code_server" {
+  count        = var.enable_apps && var.enable_code_server ? 1 : 0
+  agent_id     = var.agent_id
+  display_name = "code-server"
+  icon         = "/icon/code.svg"
+  run_on_start = true
 
-  agent_id       = var.agent_id
-  order          = 0
-  open_in        = "tab"
-  extensions_dir = "/home/coder/.vscode-extensions/shared"
-
-  settings = {
-    "workbench.colorTheme"                 = "Solarized Moon",
-    "git.useIntegratedAskPass"             = false,
-    "likec4.mcp.enabled"                   = true,
-    "todo-tree.tree.showBadges"            = true,
-    "todo-tree.tree.disableCompactFolders" = false,
-    "todo-tree.tree.showCountsInTree"      = true,
-    "todo-tree.tree.scanMode"              = "current file",
-    "mdb.showOverviewPageAfterInstall"     = false
-  }
-
-  extensions = [
-    "GitHub.vscode-github-actions",
-    "GitHub.vscode-pull-request-github",
-    "eamodio.gitlens",
-    "Anthropic.claude-code",
-    "highagency.pencildev",
-    "mongodb.mongodb-vscode",
-    "openai.chatgpt",
-    "ms-python.python",
-    "detachhead.basedpyright",
-    "Supermaven.supermaven",
-    "ms-azuretools.vscode-docker",
-    "likec4.likec4-vscode",
-    "nefrob.vscode-just-syntax",
-    "bradlc.vscode-tailwindcss",
-    "Gruntfuggly.todo-tree",
-    "usernamehw.errorlens",
-    "joshbolduc.story-explorer",
-    "bruno-api-client.bruno",
-    "pomdtr.excalidraw-editor",
-    "abridge.file-explorer-tools",
-    "hashicorp.terraform",
-    "rhalaly.scope-to-this",
-    "jakobhoeg.vscode-pokemon",
-    "d9once.pokechi",
-    "octohash.powermode-plus",
-  ]
+  script = templatefile("${path.module}/scripts/code-server-launch.sh", {
+    INSTALL_PREFIX = local.code_server_install_prefix
+    EXTENSIONS_DIR = local.code_server_extensions_dir
+    LOG_PATH       = local.code_server_log_path
+    PORT           = local.code_server_port
+    APP_NAME       = "code-server"
+  })
 }
 
+resource "coder_app" "code_server" {
+  count        = var.enable_apps && var.enable_code_server ? 1 : 0
+  agent_id     = var.agent_id
+  slug         = "code-server"
+  display_name = "code-server"
+  url          = "http://localhost:${local.code_server_port}/?folder=${urlencode("/workspaces/${var.project_name}")}"
+  icon         = "/icon/code.svg"
+  subdomain    = false
+  share        = "owner"
+  order        = 0
+  open_in      = "tab"
 
-module "vscode-web" {
-  count  = var.enable_apps && var.enable_vscode_web ? 1 : 0
-  source = "registry.coder.com/coder/vscode-web/coder"
-  folder = "/workspaces/${var.project_name}"
-
-  agent_id       = var.agent_id
-  order          = 2
-  accept_license = true
-  # vscode-web reads a merged extensions dir (shared OpenVSX extensions plus
-  # MS-marketplace-only ones). The base-dev init script symlinks the shared
-  # dir into the vscode-web dir on workspace start.
-  extensions_dir = "/home/coder/.vscode-extensions/vscode-web"
-
-  settings = {
-    "workbench.colorTheme"                 = "Default Dark Modern",
-    "git.useIntegratedAskPass"             = false,
-    "likec4.mcp.enabled"                   = true,
-    "todo-tree.tree.showBadges"            = true,
-    "todo-tree.tree.disableCompactFolders" = false,
-    "todo-tree.tree.showCountsInTree"      = true,
-    "todo-tree.tree.scanMode"              = "current file",
-    "mdb.showOverviewPageAfterInstall"     = false
+  healthcheck {
+    url       = "http://localhost:${local.code_server_port}/healthz"
+    interval  = 5
+    threshold = 6
   }
+}
 
-  extensions = [
-    "GitHub.vscode-github-actions",
-    "GitHub.vscode-pull-request-github",
-    "eamodio.gitlens",
-    "Github.copilot",
-    "Anthropic.claude-code",
-    "highagency.pencildev",
-    "mongodb.mongodb-vscode",
-    "openai.chatgpt",
-    "ms-python.python",
-    "ms-azuretools.vscode-docker",
-    "Google.geminicodeassist",
-    "likec4.likec4-vscode",
-    "nefrob.vscode-just-syntax",
-    "bradlc.vscode-tailwindcss",
-    "Gruntfuggly.todo-tree",
-    "usernamehw.errorlens",
-    "joshbolduc.story-explorer",
-    "bruno-api-client.bruno",
-    "pomdtr.excalidraw-editor",
-    "abridge.file-explorer-tools",
-    "hashicorp.terraform",
-    "rhalaly.scope-to-this",
-    "jakobhoeg.vscode-pokemon",
-    "d9once.pokechi",
-    "octohash.powermode-plus",
-  ]
+# vscode-web (Microsoft) — thin wrapper around the binary baked into base-dev.
+# Binary is installed at /opt/vscode-web/bin/code-server by the image build.
+# The launcher symlinks every subdir of the shared OpenVSX extensions dir into
+# vscode-web's own extensions dir on each start so vscode-web sees a merged
+# view (shared + Marketplace-only) with zero on-disk duplication.
+resource "coder_script" "vscode_web" {
+  count        = var.enable_apps && var.enable_vscode_web ? 1 : 0
+  agent_id     = var.agent_id
+  display_name = "VS Code Web"
+  icon         = "/icon/code.svg"
+  run_on_start = true
+
+  script = templatefile("${path.module}/scripts/vscode-web-launch.sh", {
+    INSTALL_PREFIX        = local.vscode_web_install_prefix
+    EXTENSIONS_DIR        = local.vscode_web_extensions_dir
+    SHARED_EXTENSIONS_DIR = local.vscode_web_shared_extensions
+    LOG_PATH              = local.vscode_web_log_path
+    PORT                  = local.vscode_web_port
+    TELEMETRY_LEVEL       = local.vscode_web_telemetry_level
+    SERVER_BASE_PATH      = local.vscode_web_server_base_path
+  })
+}
+
+resource "coder_app" "vscode_web" {
+  count        = var.enable_apps && var.enable_vscode_web ? 1 : 0
+  agent_id     = var.agent_id
+  slug         = "vscode-web"
+  display_name = "VS Code Web"
+  url          = "http://localhost:${local.vscode_web_port}${local.vscode_web_server_base_path}?folder=${urlencode("/workspaces/${var.project_name}")}"
+  icon         = "/icon/code.svg"
+  subdomain    = local.vscode_web_subdomain
+  share        = "owner"
+  order        = 2
+
+  healthcheck {
+    url       = local.vscode_web_subdomain ? "http://localhost:${local.vscode_web_port}/healthz" : "http://localhost:${local.vscode_web_port}${local.vscode_web_server_base_path}healthz"
+    interval  = 5
+    threshold = 6
+  }
 }
 
 

--- a/workspace-modules/workspace-apps/scripts/code-server-launch.sh
+++ b/workspace-modules/workspace-apps/scripts/code-server-launch.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# code-server launcher (replaces registry.coder.com/coder/code-server module).
+# Intentionally minimal: assumes the binary is on disk at
+# INSTALL_PREFIX/bin/code-server (baked into base-dev) and that
+# workspace-init.d has already handled extension installs and any
+# settings.json files. This script only ensures the extensions dir exists
+# and launches the binary. Templated by Terraform: any token written here
+# without escaping that matches the form of an HCL interpolation will be
+# substituted at module-eval time.
+
+set -e
+
+CODE_SERVER="${INSTALL_PREFIX}/bin/code-server"
+EXTENSIONS_DIR="${EXTENSIONS_DIR}"
+LOG_PATH="${LOG_PATH}"
+PORT="${PORT}"
+APP_NAME="${APP_NAME}"
+
+mkdir -p "$EXTENSIONS_DIR"
+
+echo "Launching code-server on 127.0.0.1:$PORT (extensions: $EXTENSIONS_DIR)"
+"$CODE_SERVER" \
+  --auth=none \
+  --bind-addr="127.0.0.1:$PORT" \
+  --app-name="$APP_NAME" \
+  --extensions-dir="$EXTENSIONS_DIR" \
+  > "$LOG_PATH" 2>&1 &
+
+echo "code-server PID $!; logs: $LOG_PATH"

--- a/workspace-modules/workspace-apps/scripts/vscode-web-launch.sh
+++ b/workspace-modules/workspace-apps/scripts/vscode-web-launch.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# vscode-web launcher (replaces registry.coder.com/coder/vscode-web module).
+# Intentionally minimal: assumes the binary is on disk at
+# INSTALL_PREFIX/bin/code-server (baked into base-dev) and that
+# workspace-init.d has already handled extension installs and any
+# settings.json files. This script only mirrors the shared OpenVSX extension
+# directory into vscode-web's extensions dir (so the editor sees a merged
+# view with zero on-disk duplication) and launches the binary. Templated by
+# Terraform: any token written here without escaping that matches the form
+# of an HCL interpolation will be substituted at module-eval time.
+
+set -e
+
+VSCODE_WEB="${INSTALL_PREFIX}/bin/code-server"
+EXTENSIONS_DIR="${EXTENSIONS_DIR}"
+SHARED_EXTENSIONS_DIR="${SHARED_EXTENSIONS_DIR}"
+LOG_PATH="${LOG_PATH}"
+PORT="${PORT}"
+TELEMETRY_LEVEL="${TELEMETRY_LEVEL}"
+SERVER_BASE_PATH="${SERVER_BASE_PATH}"
+
+mkdir -p "$EXTENSIONS_DIR" "$SHARED_EXTENSIONS_DIR"
+
+# Mirror each extension subdirectory from the shared OpenVSX dir into the
+# vscode-web extensions dir as a symlink. vscode-web reads the union (its own
+# marketplace installs + symlinked shared extensions) without on-disk
+# duplication. Real subdirectories already in vscode-web/ (its own installs)
+# are left untouched; only stale symlinks are repointed.
+shopt -s nullglob
+for ext in "$SHARED_EXTENSIONS_DIR"/*/; do
+  ext="$${ext%/}"
+  name="$(basename "$ext")"
+  link="$EXTENSIONS_DIR/$name"
+  if [ -L "$link" ] || [ ! -e "$link" ]; then
+    ln -snf "$ext" "$link"
+  fi
+done
+
+SERVER_BASE_PATH_ARG=""
+if [ -n "$SERVER_BASE_PATH" ]; then
+  SERVER_BASE_PATH_ARG="--server-base-path=$SERVER_BASE_PATH"
+fi
+
+echo "Launching vscode-web on 127.0.0.1:$PORT (extensions: $EXTENSIONS_DIR)"
+"$VSCODE_WEB" serve-local \
+  --port="$PORT" \
+  --host=127.0.0.1 \
+  --accept-server-license-terms \
+  --without-connection-token \
+  --telemetry-level="$TELEMETRY_LEVEL" \
+  --extensions-dir="$EXTENSIONS_DIR" \
+  $SERVER_BASE_PATH_ARG \
+  > "$LOG_PATH" 2>&1 &
+
+echo "vscode-web PID $!; logs: $LOG_PATH"


### PR DESCRIPTION
## Summary

PR 3/6. Replaces the `registry.coder.com/coder/{code-server,vscode-web}` modules with thin `coder_app` + `coder_script` wrappers around the binaries baked into the `base-dev` image by #38. Boot time becomes "exec what's on disk" instead of "fetch and unpack on every start".

**Stacked on #37.** Base is `feat/extension-persistence-restructure`; will auto-rebase when #37 merges.

## New files

- `workspace-modules/workspace-apps/scripts/code-server-launch.sh` — templated launcher for code-server. Writes `User/settings.json` only on first run, overwrites `Machine/settings.json` every start, points `--extensions-dir` at the shared OpenVSX dir.
- `workspace-modules/workspace-apps/scripts/vscode-web-launch.sh` — templated launcher for vscode-web. Merges machine settings via `jq`, points `--extensions-dir` at the vscode-web dir, and performs the shared → vscode-web symlink merge described below.

## The symlink merge (the interesting bit)

Every subdir of `/home/coder/.vscode-extensions/shared/` is mirrored as a symlink into `/home/coder/.vscode-extensions/vscode-web/` on each workspace start. vscode-web reads the union — its own Marketplace-only installs (Copilot, Gemini) plus all OpenVSX extensions shared with code-server — without on-disk duplication. Real subdirectories already in `vscode-web/` are left alone; only stale symlinks get repointed. Idempotent and cheap.

## What was removed

The inline `extensions = [...]` lists in both module calls. Extension installation moves to the manifest framework in PR4. Already-installed extensions in the shared host bind persist across this change (they live in `/home/ubuntu/secrets/extensions/shared`), so no existing workspace loses extensions on restart. Brand-new workspaces will have an extension-install gap until PR4 lands.

## Behavior preserved

Identical to upstream module behavior for these knobs:

| Concern | code-server | vscode-web |
|---|---|---|
| `User/settings.json` | written on first run only | not managed |
| `Machine/settings.json` | overwritten every start | merged every start (jq, falls back to overwrite) |
| `--extensions-dir` | `…/shared` | `…/vscode-web` |
| `coder_app` URL/healthcheck | path-based, port 13337 | subdomain-based, port 13338 |
| `subdomain` | false | true |
| `share` | owner | owner |
| `order` | 0 | 2 |

## Repo hygiene

Added `.terraform/` and `.terraform.lock.hcl` to root `.gitignore` so future local `terraform validate` runs don't pollute the working tree.

## Validation

- `terraform validate` clean on `workspace-modules/workspace-apps`.
- `shellcheck` clean on both launchers (only SC2269 info-level false positives on Terraform-templated values).

## Followups

- PR4 — manifest framework + Tier 1 manifests in base-dev. The launchers in this PR deliberately know nothing about extensions; PR4 wires up a separate init script chain that populates the shared dir.
- PR5 — Tier 2 manifests per env image.
- PR6 — Tier 3 reader for `.devcontainer/devcontainer.json` and `.vscode/extensions.json`.
