### PR TITLE
Tier-2 per-env extension manifests (python, frontend, fullstack)

### DIFF
--- a/workspace-images/fullstack-dev/Dockerfile
+++ b/workspace-images/fullstack-dev/Dockerfile
@@ -26,6 +26,11 @@ RUN chmod +x /usr/local/share/workspace-init.d/20-python-init.sh
 COPY workspace-images/fullstack-dev/fullstack-init.sh /usr/local/share/workspace-init.d/30-fullstack-init.sh
 RUN chmod +x /usr/local/share/workspace-init.d/30-fullstack-init.sh
 
+# Python Tier 2 manifest. The frontend Tier 2 manifest is already inherited
+# from the nextjs-dev image layer; only the python one needs an explicit COPY
+# here because fullstack-dev does not derive from python-dev.
+COPY workspace-images/python-dev/extensions.d/ /usr/local/share/workspace-extensions.d/
+
 # Fullstack-specific system prompt extension. Stacks on top of the inherited
 # nextjs-dev prompt extension (already at 20-nextjs.txt from the parent image).
 COPY workspace-images/fullstack-dev/system_prompt_extension.txt /usr/local/share/workspace-prompts/30-fullstack.txt

--- a/workspace-images/nextjs-dev/Dockerfile
+++ b/workspace-images/nextjs-dev/Dockerfile
@@ -47,6 +47,12 @@ RUN chmod +x /usr/local/share/workspace-init.d/20-nextjs-init.sh
 # by 11-agent-prompts.sh alongside the base prompt.
 COPY workspace-images/nextjs-dev/system_prompt_extension.txt /usr/local/share/workspace-prompts/20-nextjs.txt
 
+# Tier 2 (frontend) extension manifest, merged with the inherited Tier 1
+# manifest at workspace start by 25-extensions-install.sh and
+# 26-settings-apply.sh. fullstack-dev FROM nextjs-dev inherits this manifest
+# transitively via the image layer.
+COPY workspace-images/nextjs-dev/extensions.d/ /usr/local/share/workspace-extensions.d/
+
 # Set Node.js workspace defaults
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NPM_CONFIG_UPDATE_NOTIFIER=false

--- a/workspace-images/nextjs-dev/extensions.d/30-frontend.json
+++ b/workspace-images/nextjs-dev/extensions.d/30-frontend.json
@@ -1,0 +1,6 @@
+{
+  "_comment": "Tier 2 extensions manifest (nextjs-dev / future frontend-dev). Layers on top of base-dev's 10-base.json. fullstack-dev FROM nextjs-dev inherits this manifest transitively via the underlying image layer.",
+  "shared": [
+    "bradlc.vscode-tailwindcss"
+  ]
+}

--- a/workspace-images/python-dev/Dockerfile
+++ b/workspace-images/python-dev/Dockerfile
@@ -11,6 +11,10 @@ RUN chmod +x /tmp/install-python.sh && /tmp/install-python.sh && rm /tmp/install
 COPY workspace-images/python-dev/python-init.sh /usr/local/share/workspace-init.d/20-python-init.sh
 RUN chmod +x /usr/local/share/workspace-init.d/20-python-init.sh
 
+# Tier 2 (python) extension manifest, merged with the inherited Tier 1 manifest
+# at workspace start by 25-extensions-install.sh and 26-settings-apply.sh.
+COPY workspace-images/python-dev/extensions.d/ /usr/local/share/workspace-extensions.d/
+
 # Set Python environment variables
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/workspace-images/python-dev/extensions.d/30-python.json
+++ b/workspace-images/python-dev/extensions.d/30-python.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "Tier 2 extensions manifest (python-dev). Layers on top of base-dev's 10-base.json. Inherited unchanged by fullstack-dev via an explicit COPY in that image's Dockerfile (fullstack-dev FROM nextjs-dev, so it doesn't pick this up transitively).",
+  "shared": [
+    "ms-python.python",
+    "detachhead.basedpyright"
+  ]
+}


### PR DESCRIPTION
Stacked on #40. Adds Tier 2 manifests for the child images. Slots straight into the install/apply pipeline introduced in #40 with no script changes — both scripts already enumerate every `*.json` in `/usr/local/share/workspace-extensions.d/` in sort order and merge their `.settings` sections.

## Manifests

### `workspace-images/python-dev/extensions.d/30-python.json`
```json
{ "extensions": { "shared": [ "ms-python.python", "detachhead.basedpyright" ] } }
```

### `workspace-images/nextjs-dev/extensions.d/30-frontend.json`
```json
{ "extensions": { "shared": [ "bradlc.vscode-tailwindcss" ] } }
```

No settings keys yet — the existing Tier 1 machine settings are intentionally enough for now. Each env can add `.settings.machine` keys here later without touching any other PR.

## Dockerfile changes

| Image | Change |
|------|------|
| `python-dev/Dockerfile` | `COPY workspace-images/python-dev/extensions.d/ /usr/local/share/workspace-extensions.d/` |
| `nextjs-dev/Dockerfile` | `COPY workspace-images/nextjs-dev/extensions.d/ /usr/local/share/workspace-extensions.d/` |
| `fullstack-dev/Dockerfile` | `COPY workspace-images/python-dev/extensions.d/ /usr/local/share/workspace-extensions.d/` (frontend manifest is inherited from `FROM nextjs-dev`, only the python one needs an explicit COPY) |

## Result on each image

- **python-dev** → 10-base.json + 30-python.json
- **nextjs-dev** → 10-base.json + 30-frontend.json
- **fullstack-dev** → 10-base.json + 30-frontend.json (inherited) + 30-python.json (explicit COPY)

`jq` parses both new manifests; bash scripts unchanged.
