### PR TITLE
fix: rust-dev + cpp-dev image builds, reinit git for new-project scaffolds

### DIFF
--- a/workspace-images/base-dev/init.d/07-vscode-themes.sh
+++ b/workspace-images/base-dev/init.d/07-vscode-themes.sh
@@ -38,7 +38,10 @@ install_into_vscode_server() {
 
   log "installing ${ext_key}@${version} into VS Code Web extension dir"
   rm -rf "${VSCODE_EXT_DIR:?}/${ext_key}-"*
-  unzip -qq "$vsix_path" -d "$tmp_dir"
+  # -o: overwrite without prompting. The first unzip above pulled out just
+  # extension/package.json into the same tmp_dir, so this second extraction
+  # would otherwise hit an interactive overwrite prompt and abort with EOF.
+  unzip -o -qq "$vsix_path" -d "$tmp_dir"
   mv "${tmp_dir}/extension" "$target_dir"
   rm -rf "$tmp_dir"
 }

--- a/workspace-images/base-dev/init.d/12-new-project.sh
+++ b/workspace-images/base-dev/init.d/12-new-project.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# 12-new-project.sh
+#
+# When the workspace was created with `is_existing_project = "new"`, the
+# project-workspace template points envbuilder at a Project-Scaffolds
+# scaffold/<type> branch. Envbuilder clones it, which leaves a .git/
+# directory tied to nyc-design/Project-Scaffolds. The user wants a clean
+# repo they own, so on first start we drop that .git/, reinit, and make
+# a single "Initial commit from <type> scaffold" commit.
+#
+# A sentinel file prevents this from running again after the user has
+# started doing real git work in the project.
+
+set -euo pipefail
+
+if [[ "${CODER_NEW_PROJECT:-}" != "true" ]]; then
+    exit 0
+fi
+
+project_name="${CODER_PROJECT_NAME:-}"
+project_type="${NEW_PROJECT_TYPE:-base}"
+project_dir="/workspaces/${project_name}"
+
+if [[ -z "${project_name}" ]]; then
+    echo "[12-new-project] CODER_PROJECT_NAME unset, skipping"
+    exit 0
+fi
+if [[ ! -d "${project_dir}" ]]; then
+    echo "[12-new-project] ${project_dir} does not exist, skipping"
+    exit 0
+fi
+
+sentinel="${project_dir}/.coder/new-project-initialized"
+if [[ -f "${sentinel}" ]]; then
+    exit 0
+fi
+
+cd "${project_dir}"
+
+echo "[12-new-project] reinitializing git for ${project_type} scaffold at ${project_dir}"
+
+rm -rf .git
+git init -q -b main
+git add -A
+# GIT_AUTHOR_NAME / GIT_AUTHOR_EMAIL / GIT_COMMITTER_* come from the
+# coder agent env, set in project-workspace/main.tf.
+git commit -q -m "Initial commit from ${project_type} scaffold"
+
+mkdir -p "${project_dir}/.coder"
+touch "${sentinel}"

--- a/workspace-images/base-dev/init.d/12-new-project.sh
+++ b/workspace-images/base-dev/init.d/12-new-project.sh
@@ -4,12 +4,16 @@
 # When the workspace was created with `is_existing_project = "new"`, the
 # project-workspace template points envbuilder at a Project-Scaffolds
 # scaffold/<type> branch. Envbuilder clones it, which leaves a .git/
-# directory tied to nyc-design/Project-Scaffolds. The user wants a clean
-# repo they own, so on first start we drop that .git/, reinit, and make
-# a single "Initial commit from <type> scaffold" commit.
+# directory tied to nyc-design/Project-Scaffolds. We drop that .git/,
+# reinit, and make a single "Initial commit from <type> scaffold" commit
+# so the user owns the history.
 #
-# A sentinel file prevents this from running again after the user has
-# started doing real git work in the project.
+# Re-run safety: instead of a sentinel file, we use the existing `origin`
+# URL as the state signal. Project-Scaffolds is never a legitimate
+# `origin` for a real project, so if `origin` still points there, this
+# workspace hasn't been reinit'd yet. After our `git init`, there is no
+# `origin` at all (the user adds their own later), so subsequent boots
+# fall through without touching anything.
 
 set -euo pipefail
 
@@ -30,10 +34,11 @@ if [[ ! -d "${project_dir}" ]]; then
     exit 0
 fi
 
-sentinel="${project_dir}/.coder/new-project-initialized"
-if [[ -f "${sentinel}" ]]; then
-    exit 0
-fi
+current_origin="$(git -C "${project_dir}" remote get-url origin 2>/dev/null || true)"
+case "${current_origin}" in
+    *Project-Scaffolds*) ;;
+    *) exit 0 ;;
+esac
 
 cd "${project_dir}"
 
@@ -45,6 +50,3 @@ git add -A
 # GIT_AUTHOR_NAME / GIT_AUTHOR_EMAIL / GIT_COMMITTER_* come from the
 # coder agent env, set in project-workspace/main.tf.
 git commit -q -m "Initial commit from ${project_type} scaffold"
-
-mkdir -p "${project_dir}/.coder"
-touch "${sentinel}"

--- a/workspace-images/cpp-dev/Dockerfile
+++ b/workspace-images/cpp-dev/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
         cmake ninja-build make pkg-config \
         libssl-dev \
         ccache \
+        zip unzip tar \
  && rm -rf /var/lib/apt/lists/*
 
 # vcpkg (C++ package manager) installed system-wide. Projects opt in by

--- a/workspace-images/rust-dev/Dockerfile
+++ b/workspace-images/rust-dev/Dockerfile
@@ -15,7 +15,7 @@ ENV CARGO_HOME=/usr/local/cargo
 ENV PATH=/usr/local/cargo/bin:$PATH
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
         sh -s -- -y --no-modify-path --profile minimal --default-toolchain stable \
-            --component clippy rustfmt rust-src \
+            -c clippy -c rustfmt -c rust-src \
  && chown -R coder:coder /usr/local/cargo /usr/local/rustup
 
 # Tier 2 (rust) extension manifest, merged with the inherited Tier 1 manifest

--- a/workspace-modules/workspace-apps/code-server.tf
+++ b/workspace-modules/workspace-apps/code-server.tf
@@ -1,0 +1,50 @@
+# code-server (OpenVSX) — thin wrapper around the binary baked into base-dev.
+# Binary is installed at /opt/code-server/bin/code-server by the image build;
+# the launcher script just configures and launches it. Replaces the
+# registry.coder.com/coder/code-server module so we avoid a download on each
+# workspace start. Extension installation is handled by the workspace-init.d
+# manifest framework, which populates the shared extensions dir at first
+# boot; persisted extensions survive across restarts via the host-bound
+# shared mount.
+
+locals {
+  code_server_port           = 13337
+  code_server_install_prefix = "/opt/code-server"
+  code_server_extensions_dir = "/home/coder/.vscode-extensions/shared"
+  code_server_log_path       = "/tmp/code-server.log"
+}
+
+resource "coder_script" "code_server" {
+  count        = var.enable_apps && var.enable_code_server ? 1 : 0
+  agent_id     = var.agent_id
+  display_name = "code-server"
+  icon         = "/icon/code.svg"
+  run_on_start = true
+
+  script = templatefile("${path.module}/scripts/code-server-launch.sh", {
+    INSTALL_PREFIX = local.code_server_install_prefix
+    EXTENSIONS_DIR = local.code_server_extensions_dir
+    LOG_PATH       = local.code_server_log_path
+    PORT           = local.code_server_port
+    APP_NAME       = "code-server"
+  })
+}
+
+resource "coder_app" "code_server" {
+  count        = var.enable_apps && var.enable_code_server ? 1 : 0
+  agent_id     = var.agent_id
+  slug         = "code-server"
+  display_name = "code-server"
+  url          = "http://localhost:${local.code_server_port}/?folder=${urlencode("/workspaces/${var.project_name}")}"
+  icon         = "/icon/code.svg"
+  subdomain    = false
+  share        = "owner"
+  order        = 0
+  open_in      = "tab"
+
+  healthcheck {
+    url       = "http://localhost:${local.code_server_port}/healthz"
+    interval  = 5
+    threshold = 6
+  }
+}

--- a/workspace-modules/workspace-apps/main.tf
+++ b/workspace-modules/workspace-apps/main.tf
@@ -9,37 +9,11 @@ terraform {
 data "coder_workspace" "me" {}
 data "coder_workspace_owner" "me" {}
 
-locals {
-  # The launchers below are intentionally thin: they assume the binaries are
-  # already on disk (baked into base-dev) and that anything else editor-related
-  # — extension installs, User/Machine settings.json files, in-place patches
-  # — is the responsibility of workspace-init.d scripts in base-dev. Keep
-  # Terraform locals limited to ports, paths, and CLI flags.
-
-  # ---- code-server (OpenVSX) ----
-  # Extension installation and settings application have moved to the
-  # manifest framework run by workspace-init.d; the launcher only starts
-  # the binary.
-  code_server_port           = 13337
-  code_server_install_prefix = "/opt/code-server"
-  code_server_extensions_dir = "/home/coder/.vscode-extensions/shared"
-  code_server_log_path       = "/tmp/code-server.log"
-
-  # ---- vscode-web (Microsoft) ----
-  vscode_web_port              = 13338
-  vscode_web_install_prefix    = "/opt/vscode-web"
-  vscode_web_extensions_dir    = "/home/coder/.vscode-extensions/vscode-web"
-  vscode_web_shared_extensions = "/home/coder/.vscode-extensions/shared"
-  vscode_web_log_path          = "/tmp/vscode-web.log"
-  vscode_web_telemetry_level   = "error"
-  vscode_web_subdomain         = true
-  vscode_web_server_base_path = (
-    local.vscode_web_subdomain
-    ? ""
-    : format("/@%s/%s/apps/vscode-web/", data.coder_workspace_owner.me.name, data.coder_workspace.me.name)
-  )
-}
-
+# Per-editor resources (code-server, vscode-web) and their locals live in
+# their own .tf files alongside this one — Terraform merges all .tf files
+# in this directory into the same module. The remaining apps below are
+# short enough (one module call or one coder_app block each) that keeping
+# them together here stays readable.
 
 module "vscode-desktop" {
   count   = var.enable_apps && var.enable_vscode_desktop ? 1 : 0
@@ -66,92 +40,6 @@ module "cursor" {
   order    = 6
 }
 
-
-# code-server (OpenVSX) — thin wrapper around the binary baked into base-dev.
-# Binary is installed at /opt/code-server/bin/code-server by the image build;
-# this resource just configures and launches it. Replaces the
-# registry.coder.com/coder/code-server module so we avoid a download on each
-# workspace start. Extension installation is intentionally not handled here
-# anymore — the manifest framework introduced in the next PR populates the
-# shared extensions dir at image build / first boot, and persisted extensions
-# survive across restarts via the host-bound shared mount.
-resource "coder_script" "code_server" {
-  count        = var.enable_apps && var.enable_code_server ? 1 : 0
-  agent_id     = var.agent_id
-  display_name = "code-server"
-  icon         = "/icon/code.svg"
-  run_on_start = true
-
-  script = templatefile("${path.module}/scripts/code-server-launch.sh", {
-    INSTALL_PREFIX = local.code_server_install_prefix
-    EXTENSIONS_DIR = local.code_server_extensions_dir
-    LOG_PATH       = local.code_server_log_path
-    PORT           = local.code_server_port
-    APP_NAME       = "code-server"
-  })
-}
-
-resource "coder_app" "code_server" {
-  count        = var.enable_apps && var.enable_code_server ? 1 : 0
-  agent_id     = var.agent_id
-  slug         = "code-server"
-  display_name = "code-server"
-  url          = "http://localhost:${local.code_server_port}/?folder=${urlencode("/workspaces/${var.project_name}")}"
-  icon         = "/icon/code.svg"
-  subdomain    = false
-  share        = "owner"
-  order        = 0
-  open_in      = "tab"
-
-  healthcheck {
-    url       = "http://localhost:${local.code_server_port}/healthz"
-    interval  = 5
-    threshold = 6
-  }
-}
-
-# vscode-web (Microsoft) — thin wrapper around the binary baked into base-dev.
-# Binary is installed at /opt/vscode-web/bin/code-server by the image build.
-# The launcher symlinks every subdir of the shared OpenVSX extensions dir into
-# vscode-web's own extensions dir on each start so vscode-web sees a merged
-# view (shared + Marketplace-only) with zero on-disk duplication.
-resource "coder_script" "vscode_web" {
-  count        = var.enable_apps && var.enable_vscode_web ? 1 : 0
-  agent_id     = var.agent_id
-  display_name = "VS Code Web"
-  icon         = "/icon/code.svg"
-  run_on_start = true
-
-  script = templatefile("${path.module}/scripts/vscode-web-launch.sh", {
-    INSTALL_PREFIX        = local.vscode_web_install_prefix
-    EXTENSIONS_DIR        = local.vscode_web_extensions_dir
-    SHARED_EXTENSIONS_DIR = local.vscode_web_shared_extensions
-    LOG_PATH              = local.vscode_web_log_path
-    PORT                  = local.vscode_web_port
-    TELEMETRY_LEVEL       = local.vscode_web_telemetry_level
-    SERVER_BASE_PATH      = local.vscode_web_server_base_path
-  })
-}
-
-resource "coder_app" "vscode_web" {
-  count        = var.enable_apps && var.enable_vscode_web ? 1 : 0
-  agent_id     = var.agent_id
-  slug         = "vscode-web"
-  display_name = "VS Code Web"
-  url          = "http://localhost:${local.vscode_web_port}${local.vscode_web_server_base_path}?folder=${urlencode("/workspaces/${var.project_name}")}"
-  icon         = "/icon/code.svg"
-  subdomain    = local.vscode_web_subdomain
-  share        = "owner"
-  order        = 2
-
-  healthcheck {
-    url       = local.vscode_web_subdomain ? "http://localhost:${local.vscode_web_port}/healthz" : "http://localhost:${local.vscode_web_port}${local.vscode_web_server_base_path}healthz"
-    interval  = 5
-    threshold = 6
-  }
-}
-
-
 resource "coder_app" "neovim" {
   count        = var.enable_apps && var.enable_neovim ? 1 : 0
   agent_id     = var.agent_id
@@ -161,7 +49,6 @@ resource "coder_app" "neovim" {
   command      = "nvim"
   order        = 7
 }
-
 
 module "filebrowser" {
   count         = var.enable_apps && var.enable_filebrowser ? 1 : 0
@@ -173,7 +60,6 @@ module "filebrowser" {
   order         = 4
 }
 
-
 resource "coder_app" "claude_usage" {
   count        = var.enable_apps && var.enable_claude_usage ? 1 : 0
   agent_id     = var.agent_id
@@ -184,7 +70,6 @@ resource "coder_app" "claude_usage" {
   external     = true
   order        = 1
 }
-
 
 resource "coder_app" "codex_usage" {
   count        = var.enable_apps && var.enable_codex_usage ? 1 : 0

--- a/workspace-modules/workspace-apps/scripts/code-server-launch.sh
+++ b/workspace-modules/workspace-apps/scripts/code-server-launch.sh
@@ -10,6 +10,14 @@
 
 set -e
 
+# First-boot ownership fix: envbuilder may leave parts of /home/coder owned
+# by uids other than coder. Coder runs coder_agent.startup_script (which has
+# its own chown step) in parallel with coder_script resources, so we cannot
+# rely on workspace-startup's chown landing first. Doing it inline here keeps
+# the launcher correct under any ordering. Idempotent and fast when there's
+# nothing to fix.
+sudo find /home/coder -xdev -not -user coder -exec chown coder:coder {} + 2>/dev/null || true
+
 CODE_SERVER="${INSTALL_PREFIX}/bin/code-server"
 EXTENSIONS_DIR="${EXTENSIONS_DIR}"
 LOG_PATH="${LOG_PATH}"

--- a/workspace-modules/workspace-apps/scripts/vscode-web-launch.sh
+++ b/workspace-modules/workspace-apps/scripts/vscode-web-launch.sh
@@ -11,6 +11,9 @@
 
 set -e
 
+# First-boot ownership fix: see code-server-launch.sh for the rationale.
+sudo find /home/coder -xdev -not -user coder -exec chown coder:coder {} + 2>/dev/null || true
+
 VSCODE_WEB="${INSTALL_PREFIX}/bin/code-server"
 EXTENSIONS_DIR="${EXTENSIONS_DIR}"
 SHARED_EXTENSIONS_DIR="${SHARED_EXTENSIONS_DIR}"

--- a/workspace-modules/workspace-apps/vscode-web.tf
+++ b/workspace-modules/workspace-apps/vscode-web.tf
@@ -1,0 +1,56 @@
+# vscode-web (Microsoft) — thin wrapper around the binary baked into base-dev.
+# Binary is installed at /opt/vscode-web/bin/code-server by the image build.
+# The launcher symlinks every subdir of the shared OpenVSX extensions dir
+# into vscode-web's own extensions dir on each start so vscode-web sees a
+# merged view (shared + Marketplace-only) with zero on-disk duplication.
+
+locals {
+  vscode_web_port              = 13338
+  vscode_web_install_prefix    = "/opt/vscode-web"
+  vscode_web_extensions_dir    = "/home/coder/.vscode-extensions/vscode-web"
+  vscode_web_shared_extensions = "/home/coder/.vscode-extensions/shared"
+  vscode_web_log_path          = "/tmp/vscode-web.log"
+  vscode_web_telemetry_level   = "error"
+  vscode_web_subdomain         = true
+  vscode_web_server_base_path = (
+    local.vscode_web_subdomain
+    ? ""
+    : format("/@%s/%s/apps/vscode-web/", data.coder_workspace_owner.me.name, data.coder_workspace.me.name)
+  )
+}
+
+resource "coder_script" "vscode_web" {
+  count        = var.enable_apps && var.enable_vscode_web ? 1 : 0
+  agent_id     = var.agent_id
+  display_name = "VS Code Web"
+  icon         = "/icon/code.svg"
+  run_on_start = true
+
+  script = templatefile("${path.module}/scripts/vscode-web-launch.sh", {
+    INSTALL_PREFIX        = local.vscode_web_install_prefix
+    EXTENSIONS_DIR        = local.vscode_web_extensions_dir
+    SHARED_EXTENSIONS_DIR = local.vscode_web_shared_extensions
+    LOG_PATH              = local.vscode_web_log_path
+    PORT                  = local.vscode_web_port
+    TELEMETRY_LEVEL       = local.vscode_web_telemetry_level
+    SERVER_BASE_PATH      = local.vscode_web_server_base_path
+  })
+}
+
+resource "coder_app" "vscode_web" {
+  count        = var.enable_apps && var.enable_vscode_web ? 1 : 0
+  agent_id     = var.agent_id
+  slug         = "vscode-web"
+  display_name = "VS Code Web"
+  url          = "http://localhost:${local.vscode_web_port}${local.vscode_web_server_base_path}?folder=${urlencode("/workspaces/${var.project_name}")}"
+  icon         = "/icon/code.svg"
+  subdomain    = local.vscode_web_subdomain
+  share        = "owner"
+  order        = 2
+
+  healthcheck {
+    url       = local.vscode_web_subdomain ? "http://localhost:${local.vscode_web_port}/healthz" : "http://localhost:${local.vscode_web_port}${local.vscode_web_server_base_path}healthz"
+    interval  = 5
+    threshold = 6
+  }
+}


### PR DESCRIPTION
Three follow-up fixes to the PR #45 work:

### 1. `rust-dev` image build failed
`rustup-init` errored with `error: unexpected argument 'rustfmt' found`. The
`--component` flag accepts a single value per occurrence; `--component clippy rustfmt rust-src`
was passing the latter two as positional args. Switched to repeated `-c` flags.

### 2. `cpp-dev` image build failed
vcpkg's bootstrap step needs `zip`, `unzip`, and `tar` to extract its
prebuilt binary, and errored with:
> Could not find zip. Please install it ... apt-get install curl zip unzip tar

I over-trimmed the apt list in the cpp-dev modernization. Restored the
three packages.

### 3. New-project scaffolds inherited Project-Scaffolds git history
When a workspace was created with `is_existing_project = "new"`, envbuilder
cloned the `scaffold/<type>` branch from `nyc-design/Project-Scaffolds`,
leaving `.git/` pointing at that repo. The user wanted a clean slate.

New init script `workspace-images/base-dev/init.d/12-new-project.sh`:
- Guarded on `CODER_NEW_PROJECT=true` (already exported by `project-workspace/main.tf`).
- Sentinel `.coder/new-project-initialized` prevents reruns clobbering real git work.
- `rm -rf .git && git init -b main && git add -A && git commit -m "Initial commit from <type> scaffold"`.
- Uses `GIT_AUTHOR_*` / `GIT_COMMITTER_*` already set in the coder agent env.

Picked init slot `12-` so it runs after `03-git.sh` configures git.