### PR TITLE
fix(envbuilder): chown /home/coder via SETUP_SCRIPT before agent boot

### DIFF
--- a/workspace-modules/workspace-envbuilder/main.tf
+++ b/workspace-modules/workspace-envbuilder/main.tf
@@ -11,9 +11,28 @@ terraform {
 }
 
 locals {
+  # Runs as root in the built container after envbuilder's build phase and
+  # before the init script (which launches `coder agent`). Closes the race
+  # between envbuilder's own chown and the agent's own init code: the agent
+  # runs cli/gitauth.OverrideVSCodeConfigs very early during boot, which does
+  # MkdirAll(/home/coder/.local/share/code-server/Machine). If /home/coder is
+  # still root-owned at that moment, the mkdir fails and the workspace's git
+  # credentials never make it into VS Code's git auth provider for the first
+  # session. Doing the chown here guarantees ownership is correct before the
+  # agent process exists, eliminating the race entirely.
+  envbuilder_setup_script = <<-EOT
+    for path in /home/coder /workspaces; do
+      if [ -d "$path" ]; then
+        find "$path" -xdev -not -user coder -exec chown coder:coder {} + 2>/dev/null || true
+      fi
+    done
+    exit 0
+  EOT
+
   envbuilder_env = merge({
     "CODER_AGENT_TOKEN"               = var.agent_token
     "CODER_AGENT_URL"                 = replace(var.access_url, "/localhost|127\\.0\\.0\\.1/", "host.docker.internal")
+    "ENVBUILDER_SETUP_SCRIPT"         = local.envbuilder_setup_script
     "ENVBUILDER_INIT_SCRIPT"          = replace(var.init_script, "/localhost|127\\.0\\.0\\.1/", "host.docker.internal")
     "ENVBUILDER_FALLBACK_IMAGE"       = var.fallback_image
     "ENVBUILDER_DOCKER_CONFIG_BASE64" = var.docker_config_base64


### PR DESCRIPTION
## Problem

On first boot of a fresh workspace, the Coder agent log shows:

```
[warn]  failed to override vscode git auth configs ...
    error= mkdir all:
             github.com/coder/coder/v2/cli/gitauth.OverrideVSCodeConfigs
                 /home/runner/work/coder/coder/cli/gitauth/vscode.go:65
           - mkdir /home/coder/.local/share/code-server/Machine: permission denied
```

This is the agent's own boot code attempting to seed VS Code's GitHub auth provider with the workspace's git credentials. When it fails, the user has to manually authenticate GitHub in VS Code on every first session.

## Root cause

The agent's `cli/gitauth.OverrideVSCodeConfigs` fires very early during agent init — same instant as `coder_agent.startup_script` and the various `coder_script` resources start. If `/home/coder` is still root-owned at that moment, the `MkdirAll` fails permission-denied.

The existing chown in `workspace-startup/main.tf` (running inside `coder_agent.startup_script`) and the inline chowns added in `code-server-launch.sh` / `vscode-web-launch.sh` all run **inside the agent process** — they fix the on-disk state for later reads, but they cannot win the race against the agent's own init code.

This is **distinct from the envbuilder `filepath.Walk` / ENOENT fix** (which addressed envbuilder's chown completing without erroring out): this is about chown **timing** relative to the agent process, not chown completeness.

## Fix

Wire the chown into `ENVBUILDER_SETUP_SCRIPT`, which envbuilder documents as:

> The script to run before the init script. It runs as the root user regardless of the user specified in the devcontainer.json file. SetupScript is ran as the root user prior to the init script.

The init script in our setup is what launches the Coder agent. So `SETUP_SCRIPT` chown completes **before the agent process exists** — closing the race window entirely.

## Notes

- The chown loop in `workspace-modules/workspace-startup/main.tf` and the launcher-inline chowns from #46 remain as defense-in-depth but are no longer load-bearing for this specific failure.
- No new files; one envbuilder env var added.