### PR TITLE
host-services: document Claude Code support in cliproxy image

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ workspace-modules/         # Reusable Terraform modules for workspace templates
 host-services/             # docker-compose snippets that run on the host VM
 ├── coder-pwa/             # Traefik-fronted PWA installer page
 ├── agentmemory/           # Persistent memory backend (built image, GHCR)
-├── cliproxy/              # Codex + Gemini OAuth proxy (built image, GHCR)
+├── cliproxy/              # Claude Code + Codex + Gemini OAuth proxy (built image, GHCR)
 ├── headroom/              # Local prompt compression proxy (compose-only)
 ├── meridian/              # Claude Pro/Max subscription proxy (compose-only)
 └── omniroute/             # Multi-provider AI gateway incl. Kiro (compose-only)

--- a/host-services/README.md
+++ b/host-services/README.md
@@ -36,7 +36,7 @@ client / Coder Agents / workspace CLIs
   omniroute :20128 ← centralized provider router (OmniRoute)
          │
          ├─► meridian :3456    (Claude Pro/Max subscription)
-         ├─► cliproxy :8317    (Codex + Gemini subscriptions)
+         ├─► cliproxy :8317    (Claude Code + Codex + Gemini subscriptions)
          ├─► Kiro adapter      (built-in to OmniRoute)
          └─► Groq, Cerebras, Mistral, etc.  (direct API keys)
 
@@ -71,7 +71,7 @@ compression (small JSON payloads) and doesn't need centralized routing
 | `headroom`     | compose    | `ghcr.io/chopratejas/headroom`         | Yes — `/headroom/*`            | Centralized compression for all LLM traffic          |
 | `omniroute`    | compose    | `diegosouzapw/omniroute`               | Yes — `/omniroute/*` (dashboard) | Centralized provider routing                       |
 | `meridian`     | compose    | `ghcr.io/rynfar/meridian`              | No — internal only             | Claude Pro/Max subscription proxy                    |
-| `cliproxy`     | built      | `ghcr.io/nyc-design/cliproxy`          | No — internal only             | Codex + Gemini OAuth proxy                           |
+| `cliproxy`     | built      | `ghcr.io/nyc-design/cliproxy`          | No — internal only             | Claude Code + Codex + Gemini OAuth proxy             |
 | `agentmemory`  | built      | `ghcr.io/nyc-design/agentmemory`       | No — internal only             | Persistent memory backend (iii-engine + agentmemory) |
 
 All services opt into Watchtower auto-updates via the

--- a/host-services/cliproxy/Dockerfile
+++ b/host-services/cliproxy/Dockerfile
@@ -5,8 +5,9 @@
 #
 # Wraps the upstream Go binary
 # (https://github.com/router-for-me/CLIProxyAPI). Single process serves
-# both Codex (ChatGPT Plus/Pro OAuth) and Gemini (personal Google OAuth)
-# from the same auth-dir; the upstream auto-detects which credentials are
+# Codex (ChatGPT Plus/Pro OAuth), Gemini (personal Google OAuth), and
+# Claude Code (Anthropic OAuth) from the same auth-dir; the upstream
+# auto-detects which credentials are
 # present and serves whichever endpoints have valid auth.
 #
 # Multi-arch: linux/amd64 + linux/arm64.
@@ -59,6 +60,6 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/docker-entrypoint.sh"]
 
 LABEL org.opencontainers.image.title="cliproxy" \
-      org.opencontainers.image.description="CLIProxyAPI built from upstream release with config baked in. Codex (ChatGPT Plus/Pro) + Gemini (personal Google) OAuth in one process." \
+      org.opencontainers.image.description="CLIProxyAPI built from upstream release with config baked in. Codex (ChatGPT Plus/Pro) + Gemini (personal Google) + Claude Code OAuth in one process." \
       org.opencontainers.image.source="https://github.com/nyc-design/Coder-Workspaces" \
       org.opencontainers.image.licenses="MIT"

--- a/host-services/cliproxy/README.md
+++ b/host-services/cliproxy/README.md
@@ -2,8 +2,9 @@
 
 [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) built from
 upstream release with our config baked in. Single Go process serves
-**Codex (ChatGPT Plus/Pro OAuth)** and **Gemini (personal Google OAuth)**
-on `127.0.0.1:8317` inside the container.
+**Codex (ChatGPT Plus/Pro OAuth)**, **Gemini (personal Google OAuth)**,
+and **Claude Code (Anthropic OAuth)** on `127.0.0.1:8317` inside the
+container.
 
 Published to GHCR by `.github/workflows/build-cliproxy.yaml`:
 
@@ -27,19 +28,21 @@ cliproxy is **internal-only** in our stack. Only OmniRoute reaches it —
 no Traefik labels, no public URL. Public traffic flows:
 
 ```
-client → headroom → omniroute → cliproxy → chatgpt.com / generativelanguage.googleapis.com
+client → headroom → omniroute → cliproxy → chatgpt.com / generativelanguage.googleapis.com / api.anthropic.com
 ```
 
-OmniRoute registers cliproxy in two ways (verified in OmniRoute
-`open-sse/services/provider.ts`):
+OmniRoute registers cliproxy in three ways:
 
+- For Claude Code: `anthropic-compatible-cc-cliproxy-claude` provider
+  with `baseUrl=http://cliproxy:8317/v1` — handles `/v1/messages` as an
+  alternate/fallback Claude route alongside meridian.
 - For Codex: `openai-compatible-cliproxy-resp` provider with
   `baseUrl=http://cliproxy:8317/v1` and `apiType=responses` — handles
   `/v1/responses` requests.
 - For Gemini: built-in `cliproxyapi` upstream-proxy mode on the
   `gemini` provider (`PUT /api/upstream-proxy/gemini {mode: "cliproxyapi"}`),
-  which OmniRoute already wires to `localhost:8317` —
-  see `src/lib/db/upstreamProxy.ts:36`.
+  which OmniRoute wires to cliproxy's port 8317 — see OmniRoute
+  `src/lib/db/upstreamProxy.ts:36`.
 
 The internal-only posture is also defense-in-depth: the OAuth
 credentials in `/data/auth/cliproxy` stay on the docker network and
@@ -49,11 +52,14 @@ never face an inbound public path.
 
 | Path                                          | Provider             |
 |-----------------------------------------------|----------------------|
+| `POST /v1/messages`                           | Claude Code          |
+| `POST /v1/messages/count_tokens`              | Claude Code          |
 | `POST /v1/responses`                          | Codex (ChatGPT)      |
 | `POST /v1beta/models/{model}:generateContent` | Gemini native        |
 | `POST /v1internal:streamGenerateContent`      | Cloud Code Assist    |
+| `GET  /v1/models`                             | Model list (OpenAI/Claude shape) |
 | `GET  /v1beta/models`                         | Model list (Gemini)  |
-| `GET  /health`                                | Liveness             |
+| `GET  /healthz`                               | Liveness             |
 
 Reach via `http://cliproxy:8317` from any other container on the same
 docker network.
@@ -65,17 +71,29 @@ the image. From your laptop, with the container running:
 
 ```bash
 # Codex (ChatGPT Plus/Pro)
-docker exec -it cliproxy cli-proxy-api --auth-dir /data/auth/cliproxy --login codex
+docker exec -it cliproxy cli-proxy-api \
+  --config /run/cliproxy/config.yaml \
+  --auth-dir /data/auth/cliproxy \
+  --codex-login
 
 # Gemini (personal Google)
-docker exec -it cliproxy cli-proxy-api --auth-dir /data/auth/cliproxy --login gemini
+docker exec -it cliproxy cli-proxy-api \
+  --config /run/cliproxy/config.yaml \
+  --auth-dir /data/auth/cliproxy \
+  --login
+
+# Claude Code (Anthropic)
+docker exec -it cliproxy cli-proxy-api \
+  --config /run/cliproxy/config.yaml \
+  --auth-dir /data/auth/cliproxy \
+  --claude-login
 
 docker restart cliproxy
 ```
 
 Credentials land in the `cliproxy-auth` named volume and survive container
 restarts and image upgrades. Run only the providers you need — missing
-auth = 401s for that provider only; the other keeps working.
+auth = 401s for that provider only; the others keep working.
 
 ### Refresh
 
@@ -84,6 +102,9 @@ auth = 401s for that provider only; the other keeps working.
 - **Gemini**: refresh tokens are long-lived (months to years) provided
   they're used at least every 6 months. CLIProxyAPI handles refresh
   transparently.
+- **Claude Code**: refresh behavior follows Anthropic's Claude Code OAuth
+  session rules. Re-run `--claude-login` if cliproxy starts returning 401s
+  on `/v1/messages`.
 
 ## Local API key
 
@@ -109,6 +130,9 @@ but mind each account's ToS on personal-use restrictions.
   Single-user only.
 - **Gemini Advanced** is the most generous of the supported subscriptions —
   but still personal-use per Google's ToS.
+- **Claude Pro/Max via Claude Code** is available here as an alternate route
+  to meridian. Keep each account single-user; do not use one subscription
+  token as a shared team backend.
 
 ## Versions
 

--- a/host-services/cliproxy/config.yaml
+++ b/host-services/cliproxy/config.yaml
@@ -1,7 +1,8 @@
 # CLIProxyAPI configuration baked into the cliproxy image.
-# Serves BOTH Codex (ChatGPT Plus/Pro OAuth) and Gemini (personal Google
-# OAuth) from one process. The upstream auto-detects which credentials are
-# present in `auth-dir` and serves whichever endpoints have valid auth.
+# Serves Codex (ChatGPT Plus/Pro OAuth), Gemini (personal Google OAuth),
+# and Claude Code (Anthropic OAuth) from one process. The upstream
+# auto-detects which credentials are present in `auth-dir` and serves
+# whichever endpoints have valid auth.
 #
 # `__CLIPROXY_API_KEY__` is substituted at container startup by docker-entrypoint.sh
 # from the CLIPROXY_API_KEY env var (sourced from the host .env). This lets
@@ -10,9 +11,17 @@
 host: "0.0.0.0"
 port: 8317
 
-# OAuth credentials volume. Bootstrap once per provider:
-#   docker exec -it cliproxy cli-proxy-api --auth-dir /data/auth/cliproxy --login codex
-#   docker exec -it cliproxy cli-proxy-api --auth-dir /data/auth/cliproxy --login gemini
+# OAuth credentials volume. Bootstrap once per provider. CLIProxyAPI v6.10.9
+# exposes provider-specific flags for Codex/Claude, and generic --login for
+# Gemini:
+#   docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --auth-dir /data/auth/cliproxy --codex-login
+#   docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --auth-dir /data/auth/cliproxy --login
+#   docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --auth-dir /data/auth/cliproxy --claude-login
+#
+# Claude Code does not need a separate `enable-*` knob here: /v1/messages
+# is registered by CLIProxyAPI whenever the server starts. The presence of
+# a Claude OAuth JSON file in this auth-dir is what makes provider=claude
+# routable.
 auth-dir: "/data/auth/cliproxy"
 
 # Local API key — clients must present on every request so cliproxy isn't an
@@ -20,8 +29,10 @@ auth-dir: "/data/auth/cliproxy"
 api-keys:
   - "__CLIPROXY_API_KEY__"
 
-# Native Gemini endpoint shape — Anthropic-compat tools and Google SDKs hit
-# this path directly.
+# Native Gemini endpoint shape — Google SDKs / Cloud Code Assist hit this
+# path directly. Claude-compatible /v1/messages and Codex /v1/responses
+# are always registered by CLIProxyAPI; no separate enable flag is needed
+# for Claude Code.
 enable-gemini-cli-endpoint: true
 
 # Surface request errors as 4xx/5xx instead of silently retrying so callers

--- a/host-services/cliproxy/docker-compose.snippet.yml
+++ b/host-services/cliproxy/docker-compose.snippet.yml
@@ -1,19 +1,22 @@
 # Append this service to the host docker-compose on the Coder VM.
 #
-# cliproxy fronts ChatGPT Plus/Pro (Codex) and personal-Google (Gemini)
-# OAuth in one Go process. The bundled image bakes our config; OAuth
+# cliproxy fronts ChatGPT Plus/Pro (Codex), personal-Google (Gemini), and
+# Claude Code (Anthropic) OAuth in one Go process. The bundled image bakes
+# our config; OAuth
 # credentials live on the named volume so they survive image swaps from
 # watchtower.
 #
 # In our topology cliproxy is INTERNAL-ONLY: only OmniRoute reaches it.
-# OmniRoute registers cliproxy as TWO providers (verified in
-# OmniRoute open-sse/services/provider.ts):
+# OmniRoute registers cliproxy as THREE provider paths:
 #
-#   1. openai-compatible-cliproxy-resp  baseUrl=http://cliproxy:8317/v1
-#                                       apiType=responses
+#   1. anthropic-compatible-cc-cliproxy-claude  baseUrl=http://cliproxy:8317/v1
+#       → handles /v1/messages traffic (Claude Code subscription fallback)
+#
+#   2. openai-compatible-cliproxy-resp          baseUrl=http://cliproxy:8317/v1
+#                                               apiType=responses
 #       → handles /v1/responses traffic (Codex subscription)
 #
-#   2. cliproxyapi upstream-proxy mode for the gemini provider
+#   3. cliproxyapi upstream-proxy mode for the gemini provider
 #       (PUT /api/upstream-proxy/gemini {mode: "cliproxyapi"})
 #       → handles /v1beta/models/{model}:generateContent (Gemini subscription)
 #
@@ -23,8 +26,9 @@
 # in /data/auth from any direct ingress path.
 #
 # Bootstrap (one-time, browser-based; do this AFTER cliproxy is running):
-#   docker exec -it cliproxy cli-proxy-api --auth-dir /data/auth/cliproxy --login codex
-#   docker exec -it cliproxy cli-proxy-api --auth-dir /data/auth/cliproxy --login gemini
+#   docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --auth-dir /data/auth/cliproxy --codex-login
+#   docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --auth-dir /data/auth/cliproxy --login
+#   docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --auth-dir /data/auth/cliproxy --claude-login
 #   docker restart cliproxy
 #
 # Required env in the host .env:

--- a/host-services/cliproxy/docker-entrypoint.sh
+++ b/host-services/cliproxy/docker-entrypoint.sh
@@ -14,9 +14,10 @@ sed "s|__CLIPROXY_API_KEY__|${CLIPROXY_API_KEY}|g" \
 
 if [ -z "$(ls -A /data/auth/cliproxy 2>/dev/null)" ]; then
   echo "[cliproxy] no credential files in /data/auth/cliproxy" >&2
-  echo "[cliproxy] bootstrap with one or both of:" >&2
-  echo "  docker exec -it cliproxy cli-proxy-api --auth-dir /data/auth/cliproxy --login codex" >&2
-  echo "  docker exec -it cliproxy cli-proxy-api --auth-dir /data/auth/cliproxy --login gemini" >&2
+  echo "[cliproxy] bootstrap with one or more of:" >&2
+  echo "  docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --auth-dir /data/auth/cliproxy --codex-login" >&2
+  echo "  docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --auth-dir /data/auth/cliproxy --login" >&2
+  echo "  docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --auth-dir /data/auth/cliproxy --claude-login" >&2
 fi
 
 exec cli-proxy-api --config /run/cliproxy/config.yaml

--- a/host-services/headroom/README.md
+++ b/host-services/headroom/README.md
@@ -15,7 +15,7 @@ provider routing.
 client → Traefik /headroom/* → headroom :8787 → omniroute :20128
                                                     │
                                                     ├─→ meridian (Claude Pro/Max)
-                                                    ├─→ cliproxy (Codex / Gemini OAuth)
+                                                    ├─→ cliproxy (Claude Code / Codex / Gemini OAuth)
                                                     ├─→ Kiro (built-in)
                                                     └─→ direct API providers
 ```

--- a/host-services/headroom/docker-compose.snippet.yml
+++ b/host-services/headroom/docker-compose.snippet.yml
@@ -11,7 +11,7 @@
 #   client → Traefik /headroom/* → headroom :8787 → omniroute :20128
 #                                                       │
 #                                                       ├─→ meridian (Claude Code SDK; Pro/Max OAuth)
-#                                                       ├─→ cliproxy  (Codex + Gemini OAuth subscriptions)
+#                                                       ├─→ cliproxy  (Claude Code + Codex + Gemini OAuth subscriptions)
 #                                                       ├─→ Kiro      (built-in OmniRoute adapter)
 #                                                       └─→ Groq/Cerebras/Mistral/etc. (direct API keys)
 #

--- a/host-services/omniroute/README.md
+++ b/host-services/omniroute/README.md
@@ -16,8 +16,11 @@ OmniRoute dispatches based on the requested model:
 client → Traefik /headroom/* → headroom :8787 → omniroute :20128
                                                     │
                                                     ├─→ meridian :3456
-                                                    │   (claude-* models, Claude Code SDK,
+                                                    │   (claude-* primary route, Claude Code SDK,
                                                     │    backed by Pro/Max OAuth)
+                                                    │
+                                                    ├─→ cliproxy :8317 /v1/messages
+                                                    │   (claude-* fallback route, Claude Code OAuth)
                                                     │
                                                     ├─→ cliproxy :8317 /v1/responses
                                                     │   (gpt-* models, Codex subscription)
@@ -88,8 +91,9 @@ purpose-built provider classes for each:
 
 | Backend | OmniRoute provider ID prefix | `provider_specific_data.baseUrl` | apiType / mode |
 |---|---|---|---|
-| meridian (Anthropic Messages) | `anthropic-compatible-cc-meridian` | `http://meridian:3456/v1` | n/a |
+| meridian (Anthropic Messages, primary) | `anthropic-compatible-cc-meridian` | `http://meridian:3456/v1` | n/a |
 | meridian (OpenAI alias)       | `openai-compatible-meridian-oai`   | `http://meridian:3456/v1` | `chat` |
+| cliproxy (Claude Messages, fallback) | `anthropic-compatible-cc-cliproxy-claude` | `http://cliproxy:8317/v1` | n/a |
 | cliproxy (Codex Responses)    | `openai-compatible-cliproxy-resp`  | `http://cliproxy:8317/v1` | `responses` |
 | cliproxy (Gemini)             | use built-in `gemini` provider     | n/a (set upstream-proxy mode) | `cliproxyapi` mode via `PUT /api/upstream-proxy/gemini {mode: "cliproxyapi"}` |
 
@@ -101,8 +105,8 @@ provider at cliproxy on port 8317 (`src/lib/db/upstreamProxy.ts:36`) —
 no separate provider registration needed.
 
 For cliproxy auth, configure the API key as the value of `CLIPROXY_API_KEY`
-when registering each cliproxy-backed provider, so OmniRoute presents it
-on every upstream call.
+when registering each cliproxy-backed provider (Claude fallback, Codex, and
+Gemini upstream-proxy), so OmniRoute presents it on every upstream call.
 
 ## Compression: keep OmniRoute's pipeline OFF
 
@@ -174,15 +178,15 @@ meridian/cliproxy, and re-creating every routing combo.
    — must present. Without it OmniRoute will accept unauthenticated
    traffic from anyone who hits `https://llm.tapiavala.com/omniroute`.
 6. Register internal upstreams: meridian (Anthropic + OpenAI alias) and
-   cliproxy (Responses + Gemini-via-upstream-proxy). See "Wiring recipe"
+   cliproxy (Claude fallback + Responses + Gemini-via-upstream-proxy). See "Wiring recipe"
    above. **For each, configure OmniRoute to present the matching
    per-upstream API key on outbound calls** — `MERIDIAN_API_KEY` on the
    meridian provider, `CLIPROXY_API_KEY` on the cliproxy provider. Same
    values that the upstream services validate inbound.
 7. Confirm Compression Settings master switch is OFF.
 8. Configure model aliases and combos so requests for `claude-*` go to
-   meridian, `gpt-*` go to cliproxy Codex, `gemini-*` go to cliproxy
-   Gemini, etc.
+   meridian primary with cliproxy-Claude fallback, `gpt-*` go to cliproxy
+   Codex, `gemini-*` go to cliproxy Gemini, etc.
 
 ## Auth model
 

--- a/host-services/omniroute/docker-compose.snippet.yml
+++ b/host-services/omniroute/docker-compose.snippet.yml
@@ -8,8 +8,9 @@
 #
 # Topology:
 #   headroom → omniroute :20128
-#                  ├─→ meridian :3456                 (claude-* models / Claude Code SDK)
-#                  ├─→ cliproxy :8317  /v1/responses  (gpt-* / Codex subscription)
+#                  ├─→ meridian :3456                 (claude-* primary / Claude Code SDK)
+#                  ├─→ cliproxy :8317  /v1/messages    (claude-* fallback / Claude Code OAuth)
+#                  ├─→ cliproxy :8317  /v1/responses   (gpt-* / Codex subscription)
 #                  ├─→ cliproxy :8317  /v1beta/...    (gemini-* subscription)
 #                  ├─→ Kiro adapter (built-in)        (kiro/* models)
 #                  └─→ Groq, Cerebras, Mistral, etc.  (direct-key providers)


### PR DESCRIPTION
## Summary

- Updates the baked cliproxy config comments to document Claude Code OAuth as the third supported mode alongside Codex and Gemini.
- Fixes the bootstrap commands for the pinned CLIProxyAPI v6.10.9 flags: `--codex-login`, generic `--login` for Gemini, and `--claude-login`.
- Documents OmniRoute wiring for cliproxy Claude fallback: `anthropic-compatible-cc-cliproxy-claude` with `baseUrl=http://cliproxy:8317/v1`.
- Updates Dockerfile labels, entrypoint hints, compose comments, and stack READMEs to reflect Claude Code + Codex + Gemini.

## Verification

- `docker build -t cliproxy-claude-doccheck host-services/cliproxy`
- `docker run --rm --entrypoint cli-proxy-api cliproxy-claude-doccheck --help` confirmed `-claude-login`, `-codex-login`, and `-login` flags exist in v6.10.9.
- Checked upstream v6.10.9 source: `/v1/messages` is registered and OAuth files with `type=claude` synthesize provider `claude` auth.
