### PR TITLE
host-services: put OmniRoute dashboard on dedicated subdomain

### DIFF
--- a/host-services/README.md
+++ b/host-services/README.md
@@ -69,7 +69,7 @@ compression (small JSON payloads) and doesn't need centralized routing
 | Service        | Type       | Image                                  | Public via Traefik?            | Purpose                                              |
 |----------------|------------|----------------------------------------|--------------------------------|------------------------------------------------------|
 | `headroom`     | compose    | `ghcr.io/chopratejas/headroom`         | Yes — `/headroom/*`            | Centralized compression for all LLM traffic          |
-| `omniroute`    | compose    | `diegosouzapw/omniroute`               | Yes — `/omniroute/*` (dashboard) | Centralized provider routing                       |
+| `omniroute`    | compose    | `diegosouzapw/omniroute`               | Yes — `omniroute.tapiavala.com` (dashboard) | Centralized provider routing                       |
 | `meridian`     | compose    | `ghcr.io/rynfar/meridian`              | No — internal only             | Claude Pro/Max subscription proxy                    |
 | `cliproxy`     | built      | `ghcr.io/nyc-design/cliproxy`          | No — internal only             | Claude Code + Codex + Gemini OAuth proxy             |
 | `agentmemory`  | built      | `ghcr.io/nyc-design/agentmemory`       | No — internal only             | Persistent memory backend (iii-engine + agentmemory) |
@@ -84,8 +84,10 @@ rebuilt and pushed by their per-service workflow on push to `main`.
   `/v1/responses`, `/v1/chat/completions`, `/v1beta/models/.../generateContent`,
   `/v1internal:streamGenerateContent`). All four protocol shapes work
   through this single base URL.
-- **OmniRoute dashboard**: `https://llm.tapiavala.com/omniroute/` — for
-  configuring providers, OAuth flows, and routing combos.
+- **OmniRoute dashboard**: `https://omniroute.tapiavala.com/` — for
+  configuring providers, OAuth flows, and routing combos. Use a dedicated
+  host, not `/omniroute`, because OmniRoute redirects to root-relative
+  `/dashboard` and uses root-relative app/API paths.
 
 Workspaces, Coder Agents, laptop CLIs — they all use the same base URL.
 

--- a/host-services/cliproxy/README.md
+++ b/host-services/cliproxy/README.md
@@ -66,26 +66,27 @@ docker network.
 
 ## Auth bootstrap
 
-Both OAuth flows are driven by the `cli-proxy-api` CLI itself, baked into
-the image. From your laptop, with the container running:
+All OAuth flows are driven by the `cli-proxy-api` CLI itself, baked into
+the image. Pass `--config /run/cliproxy/config.yaml`; the auth directory
+is read from that config (`auth-dir: /data/auth/cliproxy`). Do **not** pass
+`--auth-dir` — CLIProxyAPI v6.10.9 does not expose that flag.
+
+From your laptop, with the container running:
 
 ```bash
 # Codex (ChatGPT Plus/Pro)
 docker exec -it cliproxy cli-proxy-api \
   --config /run/cliproxy/config.yaml \
-  --auth-dir /data/auth/cliproxy \
   --codex-login
 
 # Gemini (personal Google)
 docker exec -it cliproxy cli-proxy-api \
   --config /run/cliproxy/config.yaml \
-  --auth-dir /data/auth/cliproxy \
   --login
 
 # Claude Code (Anthropic)
 docker exec -it cliproxy cli-proxy-api \
   --config /run/cliproxy/config.yaml \
-  --auth-dir /data/auth/cliproxy \
   --claude-login
 
 docker restart cliproxy

--- a/host-services/cliproxy/config.yaml
+++ b/host-services/cliproxy/config.yaml
@@ -12,11 +12,12 @@ host: "0.0.0.0"
 port: 8317
 
 # OAuth credentials volume. Bootstrap once per provider. CLIProxyAPI v6.10.9
-# exposes provider-specific flags for Codex/Claude, and generic --login for
-# Gemini:
-#   docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --auth-dir /data/auth/cliproxy --codex-login
-#   docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --auth-dir /data/auth/cliproxy --login
-#   docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --auth-dir /data/auth/cliproxy --claude-login
+# does NOT expose an --auth-dir flag; pass --config and it reads this
+# auth-dir setting. It exposes provider-specific flags for Codex/Claude,
+# and generic --login for Gemini:
+#   docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --codex-login
+#   docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --login
+#   docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --claude-login
 #
 # Claude Code does not need a separate `enable-*` knob here: /v1/messages
 # is registered by CLIProxyAPI whenever the server starts. The presence of

--- a/host-services/cliproxy/docker-compose.snippet.yml
+++ b/host-services/cliproxy/docker-compose.snippet.yml
@@ -26,9 +26,9 @@
 # in /data/auth from any direct ingress path.
 #
 # Bootstrap (one-time, browser-based; do this AFTER cliproxy is running):
-#   docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --auth-dir /data/auth/cliproxy --codex-login
-#   docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --auth-dir /data/auth/cliproxy --login
-#   docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --auth-dir /data/auth/cliproxy --claude-login
+#   docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --codex-login
+#   docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --login
+#   docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --claude-login
 #   docker restart cliproxy
 #
 # Required env in the host .env:

--- a/host-services/cliproxy/docker-entrypoint.sh
+++ b/host-services/cliproxy/docker-entrypoint.sh
@@ -15,9 +15,9 @@ sed "s|__CLIPROXY_API_KEY__|${CLIPROXY_API_KEY}|g" \
 if [ -z "$(ls -A /data/auth/cliproxy 2>/dev/null)" ]; then
   echo "[cliproxy] no credential files in /data/auth/cliproxy" >&2
   echo "[cliproxy] bootstrap with one or more of:" >&2
-  echo "  docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --auth-dir /data/auth/cliproxy --codex-login" >&2
-  echo "  docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --auth-dir /data/auth/cliproxy --login" >&2
-  echo "  docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --auth-dir /data/auth/cliproxy --claude-login" >&2
+  echo "  docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --codex-login" >&2
+  echo "  docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --login" >&2
+  echo "  docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --claude-login" >&2
 fi
 
 exec cli-proxy-api --config /run/cliproxy/config.yaml

--- a/host-services/omniroute/README.md
+++ b/host-services/omniroute/README.md
@@ -6,6 +6,19 @@ gateway with smart routing, automatic fallback, and Kiro support
 the upstream image directly from Docker Hub
 (`diegosouzapw/omniroute:latest`).
 
+## Public dashboard host
+
+Use `https://omniroute.tapiavala.com/`, not
+`https://llm.tapiavala.com/omniroute/`. OmniRoute is a Next.js app that
+redirects `/` to `/dashboard` and uses root-relative routes such as
+`/dashboard`, `/api`, and `/v1`. A Traefik path-prefix mount can strip the
+initial `/omniroute`, but it cannot safely rewrite every root-relative
+redirect, asset, API, and websocket URL emitted by the app. A dedicated
+subdomain is the clean fix.
+
+`https://llm.tapiavala.com/headroom/*` remains the client LLM entrypoint;
+`omniroute.tapiavala.com` is just the dashboard/direct gateway host.
+
 ## Role in the topology
 
 OmniRoute is the **single provider router** for every protocol shape that
@@ -54,7 +67,7 @@ order of stability:
 | Layer                          | Format    | Scope                                                                |
 |--------------------------------|-----------|----------------------------------------------------------------------|
 | `.env` env vars                | dotenv    | Storage encryption, direct-key provider API keys, ports, OAuth client IDs |
-| Dashboard at `/omniroute`      | n/a       | Routing rules ("combos"), models, prompts, OAuth login flows, internal-upstream wiring |
+| Dashboard at `omniroute.tapiavala.com`      | n/a       | Routing rules ("combos"), models, prompts, OAuth login flows, internal-upstream wiring |
 | `config/payloadRules.json`     | JSON      | Per-model upstream payload field injection/removal (narrow scope)    |
 
 There is **no general-purpose YAML/JSON config** for providers, keys, or
@@ -82,7 +95,7 @@ the dashboard-backed encrypted SQLite db.
   redundant unless you specifically want vendor-API fallback.
 - **Routing rules ("combos"), model aliases, prompts, webhooks** — no
   file format. Configure in the dashboard at
-  `https://llm.tapiavala.com/omniroute`.
+  `https://omniroute.tapiavala.com`.
 
 ## Wiring recipe (one-time, via dashboard or POST /api/v1/providers)
 
@@ -170,13 +183,13 @@ meridian/cliproxy, and re-creating every routing combo.
 3. `docker compose up -d omniroute`. If it crashes with a permission
    error on `/app/data`, chown the host dir to the container's UID
    (see Storage section).
-4. Visit `https://llm.tapiavala.com/omniroute` and complete dashboard setup.
+4. Visit `https://omniroute.tapiavala.com` and complete dashboard setup.
 5. **Configure the client-facing API key** (Settings → Client API Keys,
    or equivalent in the dashboard). Use the value of `LLM_GATEWAY_API_KEY`
    from your `.env` (generate with `openssl rand -hex 32`). This is the
    key that external callers — Coder Agents, workspace CLIs, your laptop
    — must present. Without it OmniRoute will accept unauthenticated
-   traffic from anyone who hits `https://llm.tapiavala.com/omniroute`.
+   traffic from anyone who hits `https://omniroute.tapiavala.com`.
 6. Register internal upstreams: meridian (Anthropic + OpenAI alias) and
    cliproxy (Claude fallback + Responses + Gemini-via-upstream-proxy). See "Wiring recipe"
    above. **For each, configure OmniRoute to present the matching

--- a/host-services/omniroute/docker-compose.snippet.yml
+++ b/host-services/omniroute/docker-compose.snippet.yml
@@ -46,7 +46,7 @@
 #                            meridian service; configure on the meridian
 #                            provider entry in the OmniRoute dashboard.
 #
-# Public URL: https://llm.tapiavala.com/omniroute/* (Traefik strips prefix)
+# Public URL: https://omniroute.tapiavala.com/ (separate host, no prefix)
 # Internal:   http://omniroute:20128
 
 services:
@@ -97,11 +97,12 @@ services:
       # NOTE: OmniRoute's default port is 20128, NOT 3000 (verified in
       # CLAUDE.md). Single port for both API and dashboard.
       - "traefik.http.services.omniroute.loadbalancer.server.port=20128"
-      - "traefik.http.routers.omniroute.rule=Host(`llm.tapiavala.com`) && PathPrefix(`/omniroute`)"
+      # Separate host, not a path prefix. OmniRoute redirects / -> /dashboard
+      # and uses absolute /dashboard, /api, /v1, etc. paths internally; mounting
+      # at /omniroute breaks those redirects and asset/API URLs.
+      - "traefik.http.routers.omniroute.rule=Host(`omniroute.tapiavala.com`)"
       - "traefik.http.routers.omniroute.entrypoints=websecure"
       - "traefik.http.routers.omniroute.tls.certresolver=le"
-      - "traefik.http.routers.omniroute.middlewares=omniroute-strip"
-      - "traefik.http.middlewares.omniroute-strip.stripprefix.prefixes=/omniroute"
 
       - "com.centurylinklabs.watchtower.enable=true"
 


### PR DESCRIPTION
## Summary

- Switches OmniRoute public routing from `llm.tapiavala.com/omniroute` to `omniroute.tapiavala.com`.
- Removes the Traefik StripPrefix middleware for OmniRoute.
- Documents why path-prefix hosting breaks: OmniRoute redirects `/` to root-relative `/dashboard` and uses root-relative `/api`, `/v1`, asset, and app routes.
- Fixes cliproxy bootstrap docs from PR #53: CLIProxyAPI v6.10.9 does not expose `--auth-dir`; it reads `auth-dir` from `--config /run/cliproxy/config.yaml`.

## Correct cliproxy bootstrap commands

```bash
docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --codex-login
docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --login
docker exec -it cliproxy cli-proxy-api --config /run/cliproxy/config.yaml --claude-login
docker restart cliproxy
```

## Host change

Bare VM Traefik route becomes:

```yaml
- "traefik.http.routers.omniroute.rule=Host(`omniroute.tapiavala.com`)"
```

You also need DNS for `omniroute.tapiavala.com` pointing at the VM.
