### PR TITLE
feat: OmniRoute provider routing — providers, models, docs, secret rename

### DIFF
--- a/.github/SECRETS.md
+++ b/.github/SECRETS.md
@@ -28,7 +28,7 @@ service_account: coder-gha-secrets@coder-nt.iam.gserviceaccount.com
 |---|---|
 | `CODER_URL` | All Coder-API workflows |
 | `CODER_SESSION_TOKEN` | All Coder-API workflows |
-| `SIDECAR_SHARED_API_KEY` | `update-coder-agents-config.yaml` |
+| `LLM_GATEWAY_API_KEY` | `update-coder-agents-config.yaml` |
 | `CONTEXT7_API_KEY` | `update-coder-agents-config.yaml` |
 | `GH_PAT_FOR_MCP` | `update-coder-agents-config.yaml` (mapped to env `GITHUB_PAT` in YAML substitution) |
 | `GCP_PROJECT` | `coder-workspace-launch.yaml` |
@@ -132,12 +132,12 @@ After WIF setup, make sure the GCP secrets in the table above all exist in
 
 ```bash
 # Add a new secret + first version
-echo -n "<value>" | gcloud secrets create SIDECAR_SHARED_API_KEY \
+echo -n "<value>" | gcloud secrets create LLM_GATEWAY_API_KEY \
   --replication-policy=automatic \
   --data-file=- --project=coder-nt
 
 # Update an existing secret to a new version
-echo -n "<new-value>" | gcloud secrets versions add SIDECAR_SHARED_API_KEY \
+echo -n "<new-value>" | gcloud secrets versions add LLM_GATEWAY_API_KEY \
   --data-file=- --project=coder-nt
 ```
 
@@ -149,7 +149,7 @@ deleted (they're now in GCP Secret Manager):
 - `CODER_URL`
 - `CODER_SESSION_TOKEN`
 - `GCP_PROJECT`
-- `SIDECAR_SHARED_API_KEY` (if it was added)
+- `LLM_GATEWAY_API_KEY` (if it was added)
 - `CONTEXT7_API_KEY` (if it was added)
 - `GH_PAT_FOR_MCP` (if it was added)
 

--- a/.github/workflows/update-coder-agents-config.yaml
+++ b/.github/workflows/update-coder-agents-config.yaml
@@ -47,7 +47,7 @@ jobs:
           secrets: |-
             CODER_URL:coder-nt/CODER_URL
             CODER_SESSION_TOKEN:coder-nt/CODER_SESSION_TOKEN
-            SIDECAR_SHARED_API_KEY:coder-nt/SIDECAR_SHARED_API_KEY
+            LLM_GATEWAY_API_KEY:coder-nt/LLM_GATEWAY_API_KEY
             CONTEXT7_API_KEY:coder-nt/CONTEXT7_API_KEY
             GH_PAT_FOR_MCP:coder-nt/GH_PAT_FOR_MCP
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,7 +196,7 @@ applies four resources idempotently:
 
 `${VAR}` placeholders in YAML are substituted from the workflow's env at sync
 time — secrets live in GitHub Actions secrets (`CODER_URL`,
-`CODER_SESSION_TOKEN`, `SIDECAR_SHARED_API_KEY`, `CONTEXT7_API_KEY`,
+`CODER_SESSION_TOKEN`, `LLM_GATEWAY_API_KEY`, `CONTEXT7_API_KEY`,
 `GH_PAT_FOR_MCP`).
 
 Sync is **additive** — items only present in Coder admin (manually added
@@ -210,9 +210,10 @@ per-workspace `~/.coder/AGENTS.md` injected by the workspace agent.
 **OpenAI sidecar base URL gotcha:** Coder's OpenAI provider path handling comes
 from `fantasy/providers/openai`, which treats a custom base URL as the full API
 root and appends `/responses` directly. We keep the public provider base URL at
-`https://llm.tapiavala.com/codex` by having Traefik rewrite `/codex/*` to
-`/codex/v1/*` before stripping the `/codex` prefix, so the underlying Codex
-sidecar still receives the `/v1/*` paths it expects.
+`https://llm.tapiavala.com/headroom/v1` while the Anthropic/Google providers use
+`https://llm.tapiavala.com/headroom`. Coder's OpenAI provider appends `/responses`
+directly, so including `/v1` in the OpenAI base URL is required until Headroom is
+root-mounted on `llm.tapiavala.com`.
 
 ### Shared Install Scripts
 - `workspace-images/shared/install-python.sh` — Python apt + pip packages used by both python-dev and fullstack-dev

--- a/coder-agents-config/README.md
+++ b/coder-agents-config/README.md
@@ -63,6 +63,42 @@ and rename. After pulling, manually restore any `${VAR}` placeholders for
 secrets — the API only returns `has_api_key: true|false`, never the value,
 so secrets come out as opaque placeholders.
 
+
+## OmniRoute model aliases
+
+Coder Agents sees three provider entries (`anthropic`, `openai`, and disabled
+`google`) that all point at the Headroom → OmniRoute gateway. Distinct backends
+are selected by OmniRoute model aliases, not by separate Coder providers.
+
+Create matching OmniRoute models / combos for every alias in `models.yaml`:
+
+| Coder provider | Coder model alias | Intended OmniRoute route |
+|---|---|---|
+| `anthropic` | `claude-sonnet-4.5-omniroute-direct` | OmniRoute Claude Code OAuth provider directly |
+| `anthropic` | `claude-opus-4.5-omniroute-direct` | OmniRoute Claude Code OAuth provider directly |
+| `anthropic` | `claude-sonnet-4.5-meridian` | `anthropic-compatible-cc-meridian` → `http://meridian:3456/v1` |
+| `anthropic` | `claude-opus-4.5-meridian` | `anthropic-compatible-cc-meridian` → `http://meridian:3456/v1` |
+| `anthropic` | `claude-sonnet-4.5-cliproxy` | `anthropic-compatible-cc-cliproxy-claude` → `http://cliproxy:8317/v1` |
+| `anthropic` | `claude-opus-4.5-cliproxy` | `anthropic-compatible-cc-cliproxy-claude` → `http://cliproxy:8317/v1` |
+| `openai` | `gpt-5.1-codex-cliproxy` | `openai-compatible-cliproxy-resp` → `http://cliproxy:8317/v1`, `apiType=responses` |
+| `openai` | `gpt-5.1-codex-omniroute-direct` | OmniRoute Codex OAuth provider directly |
+| `anthropic` | `kiro-sonnet-free` | OmniRoute Kiro / AWS Builder ID route |
+| `openai` | `cerebras-qwen3-coder-free` | OmniRoute Cerebras route |
+| `openai` | `groq-qwen3-coder-free` | OmniRoute Groq route |
+| `openai` | `codestral-free` | OmniRoute Codestral/Mistral route |
+| `openai` | `opencode-zen-free` | OmniRoute OpenCode Zen route |
+
+While Headroom is still path-mounted, Coder provider base URLs are:
+
+- Anthropic/Google: `https://llm.tapiavala.com/headroom`
+- OpenAI: `https://llm.tapiavala.com/headroom/v1` because Coder's OpenAI
+  provider appends `/responses` directly.
+
+After Headroom is root-mounted on `llm.tapiavala.com`, update these to:
+
+- Anthropic/Google: `https://llm.tapiavala.com`
+- OpenAI: `https://llm.tapiavala.com/v1`
+
 ## Workflow secrets
 
 All five secrets live in **GCP Secret Manager** (project `coder-nt`) and are
@@ -74,7 +110,7 @@ fetched at workflow runtime via Workload Identity Federation. See
 |---|---|
 | `CODER_URL` | Base URL of the Coder deployment |
 | `CODER_SESSION_TOKEN` | Admin session token (Owner role) |
-| `SIDECAR_SHARED_API_KEY` | Substituted into `providers.yaml` (all 3 providers' `api_key`) |
+| `LLM_GATEWAY_API_KEY` | Substituted into `providers.yaml` for OmniRoute/Headroom gateway providers |
 | `CONTEXT7_API_KEY` | Substituted into `mcp-servers.yaml` (Context7 header) |
 | `GH_PAT_FOR_MCP` | Substituted into `mcp-servers.yaml` (GitHub MCP bearer; mapped to env `GITHUB_PAT` to match the YAML placeholder) |
 
@@ -100,7 +136,7 @@ and `GCP_WIF_SERVICE_ACCOUNT`) for the WIF auth path.
 ```bash
 export CODER_URL=https://coder.tapiavala.com
 export CODER_SESSION_TOKEN=$(coder token create --scope all 2>/dev/null | tail -1)
-export SIDECAR_SHARED_API_KEY=...   # same value used by host-services sidecars
+export LLM_GATEWAY_API_KEY=...       # client-facing OmniRoute/Headroom gateway key
 export CONTEXT7_API_KEY=...
 export GITHUB_PAT=...
 

--- a/coder-agents-config/mcp-servers.yaml
+++ b/coder-agents-config/mcp-servers.yaml
@@ -56,3 +56,15 @@ mcp_servers:
       Authorization: Bearer ${GH_PAT_FOR_MCP}
     enabled: true
     availability: default_on
+
+  - slug: omniroute
+    display_name: OmniRoute
+    description: 'OmniRoute: manage providers, combos, model aliases, API keys, policies, rate limits, and routing strategies. Read audit logs, inspect usage/cost, run evals, and trigger compression engines (Caveman/RTK). Read/write OmniRoute memory + skills.'
+    icon_url: /icon/widgets.svg
+    transport: streamable_http
+    url: https://omniroute.tapiavala.com/api/mcp/stream
+    auth_type: custom_headers
+    custom_headers:
+      x-api-key: ${LLM_GATEWAY_API_KEY}
+    enabled: true
+    availability: default_off

--- a/coder-agents-config/models.yaml
+++ b/coder-agents-config/models.yaml
@@ -4,170 +4,469 @@
 # Stable identity: `(provider, model)` tuple. This file is declarative: models
 # missing from this YAML are deleted from Coder on sync.
 #
-# Model IDs here are OmniRoute-facing aliases. Create matching OmniRoute models
-# / combos so each alias routes to the intended upstream provider.
+# Model IDs here are live OmniRoute model IDs from `GET /v1/models`.
+# Cost values are USD per 1M tokens in Coder's model_config.cost schema.
+# Most values are from OmniRoute's LiteLLM pricing sync source; dashboard-only
+# overrides require an OmniRoute manage/admin token to inspect.
 
 models:
-  # ── Claude Code subscription paths ────────────────────────────────────────
+  # ── Claude Code subscription paths (Anthropic Messages API) ────────────────
   - provider: anthropic
-    model: claude-sonnet-4.5-omniroute-direct
-    display_name: Claude Sonnet 4.5 — OmniRoute Claude Code direct
-    enabled: true
-    is_default: true
-    context_limit: 200000
-    compression_threshold: 70
-    model_config:
-      provider_options:
-        anthropic:
-          send_reasoning: true
-          thinking:
-            budget_tokens: 16000
-
-  - provider: anthropic
-    model: claude-sonnet-4.5-meridian
-    display_name: Claude Sonnet 4.5 — Meridian
-    enabled: true
-    is_default: false
-    context_limit: 200000
-    compression_threshold: 70
-    model_config:
-      provider_options:
-        anthropic:
-          send_reasoning: true
-          thinking:
-            budget_tokens: 16000
-
-  - provider: anthropic
-    model: claude-sonnet-4.5-cliproxy
-    display_name: Claude Sonnet 4.5 — CLIProxyAPI Claude Code
-    enabled: true
-    is_default: false
-    context_limit: 200000
-    compression_threshold: 70
-    model_config:
-      provider_options:
-        anthropic:
-          send_reasoning: true
-          thinking:
-            budget_tokens: 16000
-
-  - provider: anthropic
-    model: claude-opus-4.7-omniroute-direct
-    display_name: Claude Opus 4.7 — OmniRoute Claude Code direct
-    enabled: true
-    is_default: false
-    context_limit: 200000
-    compression_threshold: 70
-    model_config:
-      provider_options:
-        anthropic:
-          send_reasoning: true
-          thinking:
-            budget_tokens: 16000
-
-  - provider: anthropic
-    model: claude-opus-4.7-meridian
+    model: meridian/claude-opus-4-7
     display_name: Claude Opus 4.7 — Meridian
     enabled: true
+    is_default: true
+    context_limit: 1000000
+    compression_threshold: 20
+    model_config:
+      cost:
+        input_price_per_million_tokens: "5"
+        output_price_per_million_tokens: "25"
+        cache_read_price_per_million_tokens: "0.5"
+        cache_write_price_per_million_tokens: "6.25"
+      provider_options:
+        anthropic:
+          send_reasoning: true
+
+  - provider: anthropic
+    model: meridian/claude-opus-4-6
+    display_name: Claude Opus 4.6 — Meridian
+    enabled: true
+    is_default: false
+    context_limit: 1000000
+    compression_threshold: 20
+    model_config:
+      cost:
+        input_price_per_million_tokens: "5"
+        output_price_per_million_tokens: "25"
+        cache_read_price_per_million_tokens: "0.5"
+        cache_write_price_per_million_tokens: "6.25"
+      provider_options:
+        anthropic:
+          send_reasoning: true
+
+  - provider: anthropic
+    model: meridian/claude-sonnet-4-6
+    display_name: Claude Sonnet 4.6 — Meridian
+    enabled: true
+    is_default: false
+    context_limit: 1000000
+    compression_threshold: 20
+    model_config:
+      cost:
+        input_price_per_million_tokens: "3"
+        output_price_per_million_tokens: "15"
+        cache_read_price_per_million_tokens: "0.3"
+        cache_write_price_per_million_tokens: "3.75"
+      provider_options:
+        anthropic:
+          send_reasoning: true
+
+  - provider: anthropic
+    model: meridian/claude-haiku-4-5
+    display_name: Claude Haiku 4.5 — Meridian
+    enabled: true
     is_default: false
     context_limit: 200000
     compression_threshold: 70
     model_config:
+      cost:
+        input_price_per_million_tokens: "1"
+        output_price_per_million_tokens: "5"
+        cache_read_price_per_million_tokens: "0.1"
+        cache_write_price_per_million_tokens: "1.25"
       provider_options:
         anthropic:
           send_reasoning: true
-          thinking:
-            budget_tokens: 16000
 
   - provider: anthropic
-    model: claude-opus-4.7-cliproxy
+    model: cliproxy-claude/claude-opus-4-7
     display_name: Claude Opus 4.7 — CLIProxyAPI Claude Code
     enabled: true
     is_default: false
-    context_limit: 200000
-    compression_threshold: 70
+    context_limit: 1000000
+    compression_threshold: 20
     model_config:
+      cost:
+        input_price_per_million_tokens: "5"
+        output_price_per_million_tokens: "25"
+        cache_read_price_per_million_tokens: "0.5"
+        cache_write_price_per_million_tokens: "6.25"
       provider_options:
         anthropic:
           send_reasoning: true
-          thinking:
-            budget_tokens: 16000
 
-  # ── Codex subscription paths ──────────────────────────────────────────────
-  - provider: openai
-    model: gpt-5.1-codex-cliproxy
-    display_name: GPT-5.1 Codex — CLIProxyAPI
-    enabled: true
-    is_default: false
-    context_limit: 200000
-    compression_threshold: 70
-    model_config:
-      provider_options:
-        openai:
-          reasoning_effort: high
-          reasoning_summary: auto
-
-  - provider: openai
-    model: gpt-5.1-codex-omniroute-direct
-    display_name: GPT-5.1 Codex — OmniRoute Codex direct
-    enabled: true
-    is_default: false
-    context_limit: 200000
-    compression_threshold: 70
-    model_config:
-      provider_options:
-        openai:
-          reasoning_effort: high
-          reasoning_summary: auto
-
-  # ── Free / bundled OmniRoute routes ───────────────────────────────────────
   - provider: anthropic
-    model: kiro-sonnet-free
-    display_name: Kiro AWS Builder — Sonnet free tier
+    model: cliproxy-claude/claude-opus-4-6
+    display_name: Claude Opus 4.6 — CLIProxyAPI Claude Code
     enabled: true
     is_default: false
-    context_limit: 200000
-    compression_threshold: 70
+    context_limit: 1000000
+    compression_threshold: 20
     model_config:
+      cost:
+        input_price_per_million_tokens: "5"
+        output_price_per_million_tokens: "25"
+        cache_read_price_per_million_tokens: "0.5"
+        cache_write_price_per_million_tokens: "6.25"
       provider_options:
         anthropic:
           send_reasoning: true
-          thinking:
-            budget_tokens: 16000
 
-  - provider: openai
-    model: cerebras-qwen3-coder-free
-    display_name: Cerebras — Qwen3 Coder free tier
+  - provider: anthropic
+    model: cliproxy-claude/claude-sonnet-4-6
+    display_name: Claude Sonnet 4.6 — CLIProxyAPI Claude Code
     enabled: true
     is_default: false
-    context_limit: 131000
-    compression_threshold: 70
+    context_limit: 1000000
+    compression_threshold: 20
+    model_config:
+      cost:
+        input_price_per_million_tokens: "3"
+        output_price_per_million_tokens: "15"
+        cache_read_price_per_million_tokens: "0.3"
+        cache_write_price_per_million_tokens: "3.75"
+      provider_options:
+        anthropic:
+          send_reasoning: true
 
-  - provider: openai
-    model: groq-qwen3-coder-free
-    display_name: Groq — Qwen3 Coder free tier
-    enabled: true
-    is_default: false
-    context_limit: 131000
-    compression_threshold: 70
-
-  - provider: openai
-    model: codestral-free
-    display_name: Codestral — free tier
-    enabled: true
-    is_default: false
-    context_limit: 32000
-    compression_threshold: 70
-
-  - provider: openai
-    model: opencode-zen-free
-    display_name: OpenCode Zen — free tier
+  - provider: anthropic
+    model: cliproxy-claude/claude-haiku-4-5-20251001
+    display_name: Claude Haiku 4.5 — CLIProxyAPI Claude Code
     enabled: true
     is_default: false
     context_limit: 200000
     compression_threshold: 70
     model_config:
+      cost:
+        input_price_per_million_tokens: "1"
+        output_price_per_million_tokens: "5"
+        cache_read_price_per_million_tokens: "0.1"
+        cache_write_price_per_million_tokens: "1.25"
+      provider_options:
+        anthropic:
+          send_reasoning: true
+
+  # ── Codex subscription paths (OpenAI Responses API) ───────────────────────
+  - provider: openai
+    model: codex/gpt-5.5-xhigh
+    display_name: GPT-5.5 Codex — OmniRoute direct (xhigh)
+    enabled: true
+    is_default: false
+    context_limit: 1050000
+    compression_threshold: 20
+    model_config:
+      cost:
+        input_price_per_million_tokens: "5"
+        output_price_per_million_tokens: "30"
+        cache_read_price_per_million_tokens: "0.5"
+      provider_options:
+        openai:
+          reasoning_effort: xhigh
+          reasoning_summary: auto
+
+  - provider: openai
+    model: codex/gpt-5.5-high
+    display_name: GPT-5.5 Codex — OmniRoute direct (high)
+    enabled: true
+    is_default: false
+    context_limit: 1050000
+    compression_threshold: 20
+    model_config:
+      cost:
+        input_price_per_million_tokens: "5"
+        output_price_per_million_tokens: "30"
+        cache_read_price_per_million_tokens: "0.5"
+      provider_options:
+        openai:
+          reasoning_effort: high
+          reasoning_summary: auto
+
+  - provider: openai
+    model: codex/gpt-5.5-medium
+    display_name: GPT-5.5 Codex — OmniRoute direct (medium)
+    enabled: true
+    is_default: false
+    context_limit: 1050000
+    compression_threshold: 20
+    model_config:
+      cost:
+        input_price_per_million_tokens: "5"
+        output_price_per_million_tokens: "30"
+        cache_read_price_per_million_tokens: "0.5"
       provider_options:
         openai:
           reasoning_effort: medium
           reasoning_summary: auto
+
+  - provider: openai
+    model: codex/gpt-5.5-low
+    display_name: GPT-5.5 Codex — OmniRoute direct (low)
+    enabled: true
+    is_default: false
+    context_limit: 1050000
+    compression_threshold: 20
+    model_config:
+      cost:
+        input_price_per_million_tokens: "5"
+        output_price_per_million_tokens: "30"
+        cache_read_price_per_million_tokens: "0.5"
+      provider_options:
+        openai:
+          reasoning_effort: low
+          reasoning_summary: auto
+
+  - provider: openai
+    model: codex/gpt-5.4
+    display_name: GPT-5.4 Codex — OmniRoute direct
+    enabled: true
+    is_default: false
+    context_limit: 400000
+    compression_threshold: 70
+    model_config:
+      cost:
+        input_price_per_million_tokens: "2.5"
+        output_price_per_million_tokens: "15"
+        cache_read_price_per_million_tokens: "0.25"
+      provider_options:
+        openai:
+          reasoning_effort: high
+          reasoning_summary: auto
+
+  - provider: openai
+    model: codex/gpt-5.4-mini
+    display_name: GPT-5.4 Mini Codex — OmniRoute direct
+    enabled: true
+    is_default: false
+    context_limit: 400000
+    compression_threshold: 70
+    model_config:
+      cost:
+        input_price_per_million_tokens: "0.75"
+        output_price_per_million_tokens: "4.5"
+        cache_read_price_per_million_tokens: "0.075"
+      provider_options:
+        openai:
+          reasoning_effort: medium
+          reasoning_summary: auto
+
+  - provider: openai
+    model: codex/gpt-5.3-codex
+    display_name: GPT-5.3 Codex — OmniRoute direct
+    enabled: true
+    is_default: false
+    context_limit: 400000
+    compression_threshold: 70
+    model_config:
+      cost:
+        input_price_per_million_tokens: "1.75"
+        output_price_per_million_tokens: "14"
+        cache_read_price_per_million_tokens: "0.175"
+      provider_options:
+        openai:
+          reasoning_effort: high
+          reasoning_summary: auto
+
+  - provider: openai
+    model: codex/gpt-5.3-codex-spark
+    display_name: GPT-5.3 Codex Spark — OmniRoute direct
+    enabled: true
+    is_default: false
+    context_limit: 400000
+    compression_threshold: 70
+    model_config:
+      cost:
+        input_price_per_million_tokens: "1.75"
+        output_price_per_million_tokens: "14"
+        cache_read_price_per_million_tokens: "0.175"
+      provider_options:
+        openai:
+          reasoning_effort: medium
+          reasoning_summary: auto
+
+  - provider: openai
+    model: codex/gpt-5.2
+    display_name: GPT-5.2 — OmniRoute direct
+    enabled: true
+    is_default: false
+    context_limit: 400000
+    compression_threshold: 70
+    model_config:
+      cost:
+        input_price_per_million_tokens: "1.75"
+        output_price_per_million_tokens: "14"
+        cache_read_price_per_million_tokens: "0.175"
+      provider_options:
+        openai:
+          reasoning_effort: high
+          reasoning_summary: auto
+
+  - provider: openai
+    model: cliproxy-codex/gpt-5.5
+    display_name: GPT-5.5 — CLIProxyAPI Codex
+    enabled: true
+    is_default: false
+    context_limit: 1050000
+    compression_threshold: 20
+    model_config:
+      cost:
+        input_price_per_million_tokens: "5"
+        output_price_per_million_tokens: "30"
+        cache_read_price_per_million_tokens: "0.5"
+      provider_options:
+        openai:
+          reasoning_effort: high
+          reasoning_summary: auto
+
+  - provider: openai
+    model: cliproxy-codex/gpt-5.4
+    display_name: GPT-5.4 — CLIProxyAPI Codex
+    enabled: true
+    is_default: false
+    context_limit: 400000
+    compression_threshold: 70
+    model_config:
+      cost:
+        input_price_per_million_tokens: "2.5"
+        output_price_per_million_tokens: "15"
+        cache_read_price_per_million_tokens: "0.25"
+      provider_options:
+        openai:
+          reasoning_effort: high
+          reasoning_summary: auto
+
+  - provider: openai
+    model: cliproxy-codex/gpt-5.4-mini
+    display_name: GPT-5.4 Mini — CLIProxyAPI Codex
+    enabled: true
+    is_default: false
+    context_limit: 400000
+    compression_threshold: 70
+    model_config:
+      cost:
+        input_price_per_million_tokens: "0.75"
+        output_price_per_million_tokens: "4.5"
+        cache_read_price_per_million_tokens: "0.075"
+      provider_options:
+        openai:
+          reasoning_effort: medium
+          reasoning_summary: auto
+
+  - provider: openai
+    model: cliproxy-codex/gpt-5.3-codex
+    display_name: GPT-5.3 Codex — CLIProxyAPI Codex
+    enabled: true
+    is_default: false
+    context_limit: 400000
+    compression_threshold: 70
+    model_config:
+      cost:
+        input_price_per_million_tokens: "1.75"
+        output_price_per_million_tokens: "14"
+        cache_read_price_per_million_tokens: "0.175"
+      provider_options:
+        openai:
+          reasoning_effort: high
+          reasoning_summary: auto
+
+  - provider: openai
+    model: cliproxy-codex/gpt-5.3-codex-spark
+    display_name: GPT-5.3 Codex Spark — CLIProxyAPI Codex
+    enabled: true
+    is_default: false
+    context_limit: 400000
+    compression_threshold: 70
+    model_config:
+      cost:
+        input_price_per_million_tokens: "1.75"
+        output_price_per_million_tokens: "14"
+        cache_read_price_per_million_tokens: "0.175"
+      provider_options:
+        openai:
+          reasoning_effort: medium
+          reasoning_summary: auto
+
+  - provider: openai
+    model: cliproxy-codex/gpt-5.2
+    display_name: GPT-5.2 — CLIProxyAPI Codex
+    enabled: true
+    is_default: false
+    context_limit: 400000
+    compression_threshold: 70
+    model_config:
+      cost:
+        input_price_per_million_tokens: "1.75"
+        output_price_per_million_tokens: "14"
+        cache_read_price_per_million_tokens: "0.175"
+      provider_options:
+        openai:
+          reasoning_effort: high
+          reasoning_summary: auto
+
+  # ── Free / bundled OpenAI-compatible routes (Chat Completions API) ─────────
+  - provider: openaicompat
+    model: free-tier
+    display_name: OmniRoute Free Tier Combo
+    enabled: true
+    is_default: false
+    context_limit: 200000
+    compression_threshold: 70
+
+  - provider: openaicompat
+    model: groq/qwen/qwen3-32b
+    display_name: Groq — Qwen3 32B
+    enabled: true
+    is_default: false
+    context_limit: 131072
+    compression_threshold: 70
+    model_config:
+      cost:
+        input_price_per_million_tokens: "0.29"
+        output_price_per_million_tokens: "0.59"
+      provider_options:
+        openaicompat:
+          reasoning_effort: medium
+
+  - provider: openaicompat
+    model: cerebras/gpt-oss-120b
+    display_name: Cerebras — GPT-OSS 120B
+    enabled: true
+    is_default: false
+    context_limit: 131072
+    compression_threshold: 70
+    model_config:
+      cost:
+        input_price_per_million_tokens: "0.35"
+        output_price_per_million_tokens: "0.75"
+      provider_options:
+        openaicompat:
+          reasoning_effort: medium
+
+  - provider: openaicompat
+    model: codestral/codestral-latest
+    display_name: Codestral — Latest
+    enabled: true
+    is_default: false
+    context_limit: 32000
+    compression_threshold: 70
+    model_config:
+      cost:
+        input_price_per_million_tokens: "0"
+        output_price_per_million_tokens: "0"
+
+  - provider: openaicompat
+    model: opencode-zen/minimax-m2.5-free
+    display_name: OpenCode Zen — MiniMax M2.5 Free
+    enabled: true
+    is_default: false
+    context_limit: 204800
+    compression_threshold: 70
+    model_config:
+      cost:
+        input_price_per_million_tokens: "0.3"
+        output_price_per_million_tokens: "1.2"
+        cache_read_price_per_million_tokens: "0.03"
+        cache_write_price_per_million_tokens: "0.375"
+      provider_options:
+        openaicompat:
+          reasoning_effort: medium

--- a/coder-agents-config/models.yaml
+++ b/coder-agents-config/models.yaml
@@ -52,8 +52,8 @@ models:
             budget_tokens: 16000
 
   - provider: anthropic
-    model: claude-opus-4.5-omniroute-direct
-    display_name: Claude Opus 4.5 — OmniRoute Claude Code direct
+    model: claude-opus-4.7-omniroute-direct
+    display_name: Claude Opus 4.7 — OmniRoute Claude Code direct
     enabled: true
     is_default: false
     context_limit: 200000
@@ -66,8 +66,8 @@ models:
             budget_tokens: 16000
 
   - provider: anthropic
-    model: claude-opus-4.5-meridian
-    display_name: Claude Opus 4.5 — Meridian
+    model: claude-opus-4.7-meridian
+    display_name: Claude Opus 4.7 — Meridian
     enabled: true
     is_default: false
     context_limit: 200000
@@ -80,8 +80,8 @@ models:
             budget_tokens: 16000
 
   - provider: anthropic
-    model: claude-opus-4.5-cliproxy
-    display_name: Claude Opus 4.5 — CLIProxyAPI Claude Code
+    model: claude-opus-4.7-cliproxy
+    display_name: Claude Opus 4.7 — CLIProxyAPI Claude Code
     enabled: true
     is_default: false
     context_limit: 200000

--- a/coder-agents-config/models.yaml
+++ b/coder-agents-config/models.yaml
@@ -1,0 +1,173 @@
+# Chat model configs for Coder Agents (chatd).
+# Synced to /api/experimental/chats/model-configs by update-coder-agents-config.yaml.
+#
+# Stable identity: `(provider, model)` tuple. This file is declarative: models
+# missing from this YAML are deleted from Coder on sync.
+#
+# Model IDs here are OmniRoute-facing aliases. Create matching OmniRoute models
+# / combos so each alias routes to the intended upstream provider.
+
+models:
+  # ── Claude Code subscription paths ────────────────────────────────────────
+  - provider: anthropic
+    model: claude-sonnet-4.5-omniroute-direct
+    display_name: Claude Sonnet 4.5 — OmniRoute Claude Code direct
+    enabled: true
+    is_default: true
+    context_limit: 200000
+    compression_threshold: 70
+    model_config:
+      provider_options:
+        anthropic:
+          send_reasoning: true
+          thinking:
+            budget_tokens: 16000
+
+  - provider: anthropic
+    model: claude-sonnet-4.5-meridian
+    display_name: Claude Sonnet 4.5 — Meridian
+    enabled: true
+    is_default: false
+    context_limit: 200000
+    compression_threshold: 70
+    model_config:
+      provider_options:
+        anthropic:
+          send_reasoning: true
+          thinking:
+            budget_tokens: 16000
+
+  - provider: anthropic
+    model: claude-sonnet-4.5-cliproxy
+    display_name: Claude Sonnet 4.5 — CLIProxyAPI Claude Code
+    enabled: true
+    is_default: false
+    context_limit: 200000
+    compression_threshold: 70
+    model_config:
+      provider_options:
+        anthropic:
+          send_reasoning: true
+          thinking:
+            budget_tokens: 16000
+
+  - provider: anthropic
+    model: claude-opus-4.5-omniroute-direct
+    display_name: Claude Opus 4.5 — OmniRoute Claude Code direct
+    enabled: true
+    is_default: false
+    context_limit: 200000
+    compression_threshold: 70
+    model_config:
+      provider_options:
+        anthropic:
+          send_reasoning: true
+          thinking:
+            budget_tokens: 16000
+
+  - provider: anthropic
+    model: claude-opus-4.5-meridian
+    display_name: Claude Opus 4.5 — Meridian
+    enabled: true
+    is_default: false
+    context_limit: 200000
+    compression_threshold: 70
+    model_config:
+      provider_options:
+        anthropic:
+          send_reasoning: true
+          thinking:
+            budget_tokens: 16000
+
+  - provider: anthropic
+    model: claude-opus-4.5-cliproxy
+    display_name: Claude Opus 4.5 — CLIProxyAPI Claude Code
+    enabled: true
+    is_default: false
+    context_limit: 200000
+    compression_threshold: 70
+    model_config:
+      provider_options:
+        anthropic:
+          send_reasoning: true
+          thinking:
+            budget_tokens: 16000
+
+  # ── Codex subscription paths ──────────────────────────────────────────────
+  - provider: openai
+    model: gpt-5.1-codex-cliproxy
+    display_name: GPT-5.1 Codex — CLIProxyAPI
+    enabled: true
+    is_default: false
+    context_limit: 200000
+    compression_threshold: 70
+    model_config:
+      provider_options:
+        openai:
+          reasoning_effort: high
+          reasoning_summary: auto
+
+  - provider: openai
+    model: gpt-5.1-codex-omniroute-direct
+    display_name: GPT-5.1 Codex — OmniRoute Codex direct
+    enabled: true
+    is_default: false
+    context_limit: 200000
+    compression_threshold: 70
+    model_config:
+      provider_options:
+        openai:
+          reasoning_effort: high
+          reasoning_summary: auto
+
+  # ── Free / bundled OmniRoute routes ───────────────────────────────────────
+  - provider: anthropic
+    model: kiro-sonnet-free
+    display_name: Kiro AWS Builder — Sonnet free tier
+    enabled: true
+    is_default: false
+    context_limit: 200000
+    compression_threshold: 70
+    model_config:
+      provider_options:
+        anthropic:
+          send_reasoning: true
+          thinking:
+            budget_tokens: 16000
+
+  - provider: openai
+    model: cerebras-qwen3-coder-free
+    display_name: Cerebras — Qwen3 Coder free tier
+    enabled: true
+    is_default: false
+    context_limit: 131000
+    compression_threshold: 70
+
+  - provider: openai
+    model: groq-qwen3-coder-free
+    display_name: Groq — Qwen3 Coder free tier
+    enabled: true
+    is_default: false
+    context_limit: 131000
+    compression_threshold: 70
+
+  - provider: openai
+    model: codestral-free
+    display_name: Codestral — free tier
+    enabled: true
+    is_default: false
+    context_limit: 32000
+    compression_threshold: 70
+
+  - provider: openai
+    model: opencode-zen-free
+    display_name: OpenCode Zen — free tier
+    enabled: true
+    is_default: false
+    context_limit: 200000
+    compression_threshold: 70
+    model_config:
+      provider_options:
+        openai:
+          reasoning_effort: medium
+          reasoning_summary: auto

--- a/coder-agents-config/providers.yaml
+++ b/coder-agents-config/providers.yaml
@@ -17,18 +17,32 @@ providers:
   #   - CLIProxyAPI Claude Code OAuth fallback
   - provider: anthropic
     display_name: OmniRoute Anthropic Gateway
-    base_url: https://llm.tapiavala.com/headroom
+    base_url: https://llm.tapiavala.com
     api_key: ${LLM_GATEWAY_API_KEY}
     enabled: true
     central_api_key_enabled: true
     allow_user_api_key: false
     allow_central_api_key_fallback: false
 
-  # Canonical OpenAI-compatible entrypoint. Codex and OpenAI-compatible free-tier
-  # providers are distinguished by model alias in OmniRoute.
+  # Canonical OpenAI Responses-API entrypoint. Codex models use `/v1/responses`
+  # end-to-end through Headroom and OmniRoute.
   - provider: openai
     display_name: OmniRoute OpenAI Gateway
-    base_url: https://llm.tapiavala.com/headroom/v1
+    base_url: https://llm.tapiavala.com/v1
+    api_key: ${LLM_GATEWAY_API_KEY}
+    enabled: true
+    central_api_key_enabled: true
+    allow_user_api_key: false
+    allow_central_api_key_fallback: false
+
+  # Chat-Completions-only entrypoint. Fantasy `openaicompat` does NOT call
+  # WithUseResponsesAPI(), so this provider talks `/v1/chat/completions` end-to-end.
+  # Used for upstreams that only speak Chat Completions: Cerebras, Groq, Codestral,
+  # OpenCode Zen, and any other non-Responses OpenAI-shaped provider routed through
+  # OmniRoute combos.
+  - provider: openaicompat
+    display_name: OmniRoute OpenAI-Compatible Gateway
+    base_url: https://llm.tapiavala.com/v1
     api_key: ${LLM_GATEWAY_API_KEY}
     enabled: true
     central_api_key_enabled: true
@@ -39,7 +53,7 @@ providers:
   # route Gemini / Cloud Code Assist through OmniRoute for Coder Agents.
   - provider: google
     display_name: OmniRoute Gemini Gateway
-    base_url: https://llm.tapiavala.com/headroom
+    base_url: https://llm.tapiavala.com
     api_key: ${LLM_GATEWAY_API_KEY}
     enabled: false
     central_api_key_enabled: true

--- a/coder-agents-config/providers.yaml
+++ b/coder-agents-config/providers.yaml
@@ -10,28 +10,37 @@
 # workflow from GitHub repo secrets / GCP Secret Manager).
 
 providers:
+  # Canonical Anthropic-compatible entrypoint. Every claude-* model below is
+  # routed by OmniRoute combos to one of:
+  #   - Claude Code direct OAuth in OmniRoute
+  #   - Meridian (Claude Code SDK / Pro-Max OAuth)
+  #   - CLIProxyAPI Claude Code OAuth fallback
   - provider: anthropic
-    display_name: Anthropic (Pro/Max via Sidecar)
-    base_url: https://llm.tapiavala.com/claude
-    api_key: ${SIDECAR_SHARED_API_KEY}
+    display_name: OmniRoute Anthropic Gateway
+    base_url: https://llm.tapiavala.com/headroom
+    api_key: ${LLM_GATEWAY_API_KEY}
     enabled: true
     central_api_key_enabled: true
     allow_user_api_key: false
     allow_central_api_key_fallback: false
 
+  # Canonical OpenAI-compatible entrypoint. Codex and OpenAI-compatible free-tier
+  # providers are distinguished by model alias in OmniRoute.
   - provider: openai
-    display_name: OpenAI Codex (ChatGPT Plus via Sidecar)
-    base_url: https://llm.tapiavala.com/codex
-    api_key: ${SIDECAR_SHARED_API_KEY}
+    display_name: OmniRoute OpenAI Gateway
+    base_url: https://llm.tapiavala.com/headroom/v1
+    api_key: ${LLM_GATEWAY_API_KEY}
     enabled: true
     central_api_key_enabled: true
     allow_user_api_key: false
     allow_central_api_key_fallback: false
 
+  # Gemini/native Google-shaped entrypoint. Leave disabled until we explicitly
+  # route Gemini / Cloud Code Assist through OmniRoute for Coder Agents.
   - provider: google
-    display_name: Google Gemini (Subscription via Sidecar)
-    base_url: https://llm.tapiavala.com/gemini
-    api_key: ${SIDECAR_SHARED_API_KEY}
+    display_name: OmniRoute Gemini Gateway
+    base_url: https://llm.tapiavala.com/headroom
+    api_key: ${LLM_GATEWAY_API_KEY}
     enabled: false
     central_api_key_enabled: true
     allow_user_api_key: false

--- a/coder-agents-config/sync.sh
+++ b/coder-agents-config/sync.sh
@@ -17,7 +17,7 @@
 # Required env:
 #   CODER_URL              base URL of the Coder deployment
 #   CODER_SESSION_TOKEN    admin session token (Owner role)
-#   SIDECAR_SHARED_API_KEY shared secret for the host-services sidecars (push only)
+#   LLM_GATEWAY_API_KEY client-facing OmniRoute/Headroom gateway key (push only)
 #   CONTEXT7_API_KEY       Context7 API key (push only)
 #   GITHUB_PAT             GitHub PAT for the github MCP server (push only)
 #
@@ -275,7 +275,7 @@ pull_all() {
   coder_get '/api/experimental/chats/providers' | \
     jq '{providers: [.[] | select(.id != "" and .id != "00000000-0000-0000-0000-000000000000")
                     | {provider, display_name, base_url,
-                       api_key: (if .has_api_key then "${SIDECAR_SHARED_API_KEY}" else null end),
+                       api_key: (if .has_api_key then "${LLM_GATEWAY_API_KEY}" else null end),
                        enabled, central_api_key_enabled, allow_user_api_key,
                        allow_central_api_key_fallback}
                     | with_entries(select(.value != null))]}' | \


### PR DESCRIPTION
## Summary

Adds Coder Agents provider + model definitions that route through the new OmniRoute gateway (`llm.tapiavala.com/headroom` → Headroom → OmniRoute → downstream).

Renames the shared gateway secret from `SIDECAR_SHARED_API_KEY` → `LLM_GATEWAY_API_KEY` everywhere it's referenced (workflow, sync script, SECRETS doc, providers.yaml, CLAUDE.md).

## Providers (`coder-agents-config/providers.yaml`)

| provider | base_url | enabled |
|---|---|---|
| anthropic | `https://llm.tapiavala.com/headroom` | true |
| openai | `https://llm.tapiavala.com/headroom/v1` | true |
| google | `https://llm.tapiavala.com/headroom` | false |

OpenAI base URL includes `/v1` because Coder's `fantasy` library appends `/responses` directly to the base URL.

## Models (`coder-agents-config/models.yaml`, new)

13 aliases covering every OmniRoute route we want exposed in Coder Agents chat:

**Claude subscription paths**
- `claude-sonnet-4.5-omniroute-direct` (default)
- `claude-sonnet-4.5-meridian`
- `claude-sonnet-4.5-cliproxy`
- `claude-opus-4.5-omniroute-direct`
- `claude-opus-4.5-meridian`
- `claude-opus-4.5-cliproxy`

**Codex subscription paths**
- `gpt-5.1-codex-cliproxy`
- `gpt-5.1-codex-omniroute-direct`

**Free tiers**
- `kiro-sonnet-free` (Kiro AWS Builder)
- `cerebras-qwen3-coder-free`
- `groq-qwen3-coder-free`
- `codestral-free`
- `opencode-zen-free`

All Anthropic models set `send_reasoning: true` + `thinking.budget_tokens: 16000`. Codex/OpenCode-Zen set `reasoning_effort` + `reasoning_summary: auto`.

## Secret rename

- `.github/workflows/update-coder-agents-config.yaml` — GCP fetch `LLM_GATEWAY_API_KEY:coder-nt/LLM_GATEWAY_API_KEY`
- `.github/SECRETS.md` — table + gcloud commands
- `coder-agents-config/sync.sh` — pull-mode jq template + comments
- `CLAUDE.md` — secret name + OpenAI `/v1` note

## Follow-ups

- Store `LLM_GATEWAY_API_KEY` in GCP secret manager (`coder-nt` project) before next agent-config sync.
- Create matching OmniRoute combos/models in the dashboard (see chat for routes per alias).