### PR TITLE
meridian: document one-time chown for meridian-data volume

### DIFF
--- a/host-services/meridian/README.md
+++ b/host-services/meridian/README.md
@@ -56,47 +56,20 @@ which is the supported way per upstream docs:
 ```yaml
 MERIDIAN_PROFILES: '[{"id":"default","oauthToken":"${CLAUDE_CODE_OAUTH_TOKEN}"}]'
 MERIDIAN_DEFAULT_PROFILE: default
-CLAUDE_CONFIG_DIR: /home/claude/.claude
 ```
 
-`MERIDIAN_PROFILES` alone is **not enough**. Meridian reads the OAuth
-token from the profile JSON on startup and keeps it in memory, which is
-fine for short chat-only requests (e.g. haiku, `tools=0`). But the
-Claude Code SDK's tool-loop code path (opus + large tool surfaces, ~60
-MCP tools attached) re-reads `$CLAUDE_CONFIG_DIR/.credentials.json` at
-request time — if that file doesn't exist the request fails silently
-with all client tools "deferred" and an empty SDK response.
+Not setting `MERIDIAN_PROFILES` and only providing `CLAUDE_CODE_OAUTH_TOKEN`
+is NOT enough — the SDK's 401-recovery would otherwise look at
+`/home/claude/.claude` credentials that don't exist in this image.
 
-The fix is two-fold and matches the original s6 sidecar setup:
-
-1. Set `CLAUDE_CONFIG_DIR=/home/claude/.claude` explicitly so the SDK
-   has a well-known location.
-2. Persist that directory via a named volume (`meridian-claude-sdk`) so
-   `.credentials.json` survives container restarts.
-
-For the credentials file itself, one-time bootstrap after first start:
-
-```bash
-docker exec -it meridian claude login
-# browser flow; credentials.json lands in /home/claude/.claude/
-```
-
-This writes `/home/claude/.claude/.credentials.json` once and the SDK
-refreshes it in-place on its ~8h cycle thereafter. If you'd rather
-avoid the browser flow, the `MERIDIAN_PROFILES` token still works for
-the chat path; the volume + `CLAUDE_CONFIG_DIR` are required for the
-tool-loop path.
-
-~1 year lifetime on the setup-token; refresh by re-running
-`claude setup-token`, updating `.env`, and `docker restart meridian`.
-If using `claude login`, refreshes are automatic until the underlying
-Claude account session expires (months).
+~1 year lifetime; refresh by re-running `claude setup-token`, updating
+`.env`, and `docker restart meridian`.
 
 The named `meridian-data` volume preserves per-profile SDK session state
-at `/home/claude/.config/meridian/profiles/default/` across image swaps.
-The `meridian-claude-sdk` volume preserves SDK credentials and config
-at `/home/claude/.claude/`. Together, watchtower upgrades don't reset
-conversation continuity or force re-auth.
+at `/home/claude/.config/meridian/profiles/default/` across image swaps,
+so watchtower upgrades don't reset conversation continuity. The OAuth
+token itself is delivered via env (never written to disk) so rotation is
+just a `docker restart`.
 
 ## Inbound auth (`MERIDIAN_API_KEY`)
 

--- a/host-services/meridian/README.md
+++ b/host-services/meridian/README.md
@@ -56,20 +56,47 @@ which is the supported way per upstream docs:
 ```yaml
 MERIDIAN_PROFILES: '[{"id":"default","oauthToken":"${CLAUDE_CODE_OAUTH_TOKEN}"}]'
 MERIDIAN_DEFAULT_PROFILE: default
+CLAUDE_CONFIG_DIR: /home/claude/.claude
 ```
 
-Not setting `MERIDIAN_PROFILES` and only providing `CLAUDE_CODE_OAUTH_TOKEN`
-is NOT enough — the SDK's 401-recovery would otherwise look at
-`/home/claude/.claude` credentials that don't exist in this image.
+`MERIDIAN_PROFILES` alone is **not enough**. Meridian reads the OAuth
+token from the profile JSON on startup and keeps it in memory, which is
+fine for short chat-only requests (e.g. haiku, `tools=0`). But the
+Claude Code SDK's tool-loop code path (opus + large tool surfaces, ~60
+MCP tools attached) re-reads `$CLAUDE_CONFIG_DIR/.credentials.json` at
+request time — if that file doesn't exist the request fails silently
+with all client tools "deferred" and an empty SDK response.
 
-~1 year lifetime; refresh by re-running `claude setup-token`, updating
-`.env`, and `docker restart meridian`.
+The fix is two-fold and matches the original s6 sidecar setup:
+
+1. Set `CLAUDE_CONFIG_DIR=/home/claude/.claude` explicitly so the SDK
+   has a well-known location.
+2. Persist that directory via a named volume (`meridian-claude-sdk`) so
+   `.credentials.json` survives container restarts.
+
+For the credentials file itself, one-time bootstrap after first start:
+
+```bash
+docker exec -it meridian claude login
+# browser flow; credentials.json lands in /home/claude/.claude/
+```
+
+This writes `/home/claude/.claude/.credentials.json` once and the SDK
+refreshes it in-place on its ~8h cycle thereafter. If you'd rather
+avoid the browser flow, the `MERIDIAN_PROFILES` token still works for
+the chat path; the volume + `CLAUDE_CONFIG_DIR` are required for the
+tool-loop path.
+
+~1 year lifetime on the setup-token; refresh by re-running
+`claude setup-token`, updating `.env`, and `docker restart meridian`.
+If using `claude login`, refreshes are automatic until the underlying
+Claude account session expires (months).
 
 The named `meridian-data` volume preserves per-profile SDK session state
-at `/home/claude/.config/meridian/profiles/default/` across image swaps,
-so watchtower upgrades don't reset conversation continuity. The OAuth
-token itself is delivered via env (never written to disk) so rotation is
-just a `docker restart`.
+at `/home/claude/.config/meridian/profiles/default/` across image swaps.
+The `meridian-claude-sdk` volume preserves SDK credentials and config
+at `/home/claude/.claude/`. Together, watchtower upgrades don't reset
+conversation continuity or force re-auth.
 
 ## Inbound auth (`MERIDIAN_API_KEY`)
 

--- a/host-services/meridian/docker-compose.snippet.yml
+++ b/host-services/meridian/docker-compose.snippet.yml
@@ -36,6 +36,20 @@
 # any other docker-network caller without the key is rejected. Generate
 # with `openssl rand -hex 32` and configure the SAME value on the
 # meridian provider entry in the OmniRoute dashboard.
+#
+# One-time manual step after `docker compose up -d` on a fresh VM:
+# the upstream image creates /home/claude/.config/meridian as root, so a
+# freshly-initialized meridian-data named volume inherits root:root
+# ownership. Meridian runs as user `claude` (uid 1000) and can't create
+# profiles/<id>/ under a root-owned parent, so the profile resolver
+# silently no-ops and SDK calls that need the profile dir (opus +
+# tool-loop requests; haiku chat path is unaffected) fail to authenticate.
+# Symptom: meridian log shows `deferred=N/N tools (...)` for an opus
+# request with no following `usage:` line. Fix:
+#   docker exec -u 0 meridian chown -R claude:claude /home/claude/.config/meridian
+#   docker restart meridian
+# Only needed once per volume — survives image swaps and container
+# restarts after that.
 
 services:
   meridian:

--- a/host-services/meridian/docker-compose.snippet.yml
+++ b/host-services/meridian/docker-compose.snippet.yml
@@ -65,15 +65,31 @@ services:
       # network. Defense-in-depth against any other container on the same
       # network accidentally hitting meridian directly.
       MERIDIAN_API_KEY: ${MERIDIAN_API_KEY:?set in .env}
+      # The Claude Code SDK (bundled inside meridian) reads/writes a
+      # persistent credentials file at $CLAUDE_CONFIG_DIR/.credentials.json.
+      # MERIDIAN_PROFILES alone keeps the OAuth token in-memory, which is
+      # enough for short chat-only requests but the tool-loop code path
+      # (long tool surfaces, e.g. opus with 60+ MCP tools attached) re-reads
+      # the credentials file at request time and fails with no file present.
+      # The original s6 sidecar (pre-split) set this explicitly; restore it.
+      CLAUDE_CONFIG_DIR: /home/claude/.claude
     volumes:
       # Per-profile SDK state lives under ~/.config/meridian/profiles/<id>/
       # (sessions, settings — never the credential, which is delivered via
       # MERIDIAN_PROFILES). Mounting the whole meridian config dir keeps
       # session continuity across container restarts and image swaps.
       - meridian-data:/home/claude/.config/meridian
+      # Persistent Claude Code SDK config + credentials directory. Without
+      # this, ~/.claude/.credentials.json never materializes and tool-loop
+      # requests (opus + large tool surfaces) fail with a credentials lookup
+      # error while chat-only requests (haiku, tools=0) still succeed. The
+      # old s6 sidecar mounted /data/auth (covering both cliproxy and the
+      # claude SDK); here we only need the claude SDK dir.
+      - meridian-claude-sdk:/home/claude/.claude
     labels:
       # Watchtower auto-update opt-in (no Traefik labels: internal-only).
       - "com.centurylinklabs.watchtower.enable=true"
 
 volumes:
   meridian-data:
+  meridian-claude-sdk:

--- a/host-services/meridian/docker-compose.snippet.yml
+++ b/host-services/meridian/docker-compose.snippet.yml
@@ -65,31 +65,15 @@ services:
       # network. Defense-in-depth against any other container on the same
       # network accidentally hitting meridian directly.
       MERIDIAN_API_KEY: ${MERIDIAN_API_KEY:?set in .env}
-      # The Claude Code SDK (bundled inside meridian) reads/writes a
-      # persistent credentials file at $CLAUDE_CONFIG_DIR/.credentials.json.
-      # MERIDIAN_PROFILES alone keeps the OAuth token in-memory, which is
-      # enough for short chat-only requests but the tool-loop code path
-      # (long tool surfaces, e.g. opus with 60+ MCP tools attached) re-reads
-      # the credentials file at request time and fails with no file present.
-      # The original s6 sidecar (pre-split) set this explicitly; restore it.
-      CLAUDE_CONFIG_DIR: /home/claude/.claude
     volumes:
       # Per-profile SDK state lives under ~/.config/meridian/profiles/<id>/
       # (sessions, settings — never the credential, which is delivered via
       # MERIDIAN_PROFILES). Mounting the whole meridian config dir keeps
       # session continuity across container restarts and image swaps.
       - meridian-data:/home/claude/.config/meridian
-      # Persistent Claude Code SDK config + credentials directory. Without
-      # this, ~/.claude/.credentials.json never materializes and tool-loop
-      # requests (opus + large tool surfaces) fail with a credentials lookup
-      # error while chat-only requests (haiku, tools=0) still succeed. The
-      # old s6 sidecar mounted /data/auth (covering both cliproxy and the
-      # claude SDK); here we only need the claude SDK dir.
-      - meridian-claude-sdk:/home/claude/.claude
     labels:
       # Watchtower auto-update opt-in (no Traefik labels: internal-only).
       - "com.centurylinklabs.watchtower.enable=true"
 
 volumes:
   meridian-data:
-  meridian-claude-sdk:


### PR DESCRIPTION
## Problem

Opus requests through meridian that involve the tool loop hang at `deferred=N/N tools (...)` and never produce a `usage:` line. Haiku chat requests (no tools) still succeed.

## Root cause

The upstream `ghcr.io/rynfar/meridian:latest` image creates `/home/claude/.config/meridian` as root at build time. When docker initializes a fresh `meridian-data` named volume on that path, the mount inherits the dir's `root:root 0755` ownership. Meridian runs as user `claude` (uid 1000) and cannot create `profiles/<id>/` under a root-owned parent, so the profile resolver silently no-ops. The SDK subprocess then fails to authenticate for tool-loop paths (haiku chat doesn't touch the profile dir, which is why it still works).

Verified live:
```
$ docker exec meridian ls -lad /home/claude/.config/meridian
drwxr-xr-x 2 root root ... /home/claude/.config/meridian
```

## Fix

One-time manual remediation per VM / per fresh volume:
```
docker exec -u 0 meridian chown -R claude:claude /home/claude/.config/meridian
docker restart meridian
```

This survives image swaps and container restarts — only needs to be re-run if the named volume itself is destroyed.

This PR just adds a comment to `host-services/meridian/docker-compose.snippet.yml` documenting the symptom and the remediation, rather than encoding it into the service definition (init container / entrypoint shim alternatives were prototyped and discarded as overkill for a one-time per-volume action).