### PR TITLE
agentmemory: expose at memory.tapiavala.com behind Bearer auth

### DIFF
--- a/.github/SECRETS.md
+++ b/.github/SECRETS.md
@@ -31,6 +31,7 @@ service_account: coder-gha-secrets@coder-nt.iam.gserviceaccount.com
 | `LLM_GATEWAY_API_KEY` | `update-coder-agents-config.yaml` |
 | `CONTEXT7_API_KEY` | `update-coder-agents-config.yaml` |
 | `GH_PAT_FOR_MCP` | `update-coder-agents-config.yaml` (mapped to env `GITHUB_PAT` in YAML substitution) |
+| `AGENTMEMORY_SECRET` | `update-coder-agents-config.yaml` (substituted into `mcp-servers.yaml`); host `.env` (gates agentmemory REST + MCP via Bearer auth) |
 | `GCP_PROJECT` | `coder-workspace-launch.yaml` |
 
 Plus the workspace-side secrets unchanged: `GH_PAT`, `DOCKER_CONFIG`,

--- a/.github/workflows/update-coder-agents-config.yaml
+++ b/.github/workflows/update-coder-agents-config.yaml
@@ -50,6 +50,7 @@ jobs:
             LLM_GATEWAY_API_KEY:coder-nt/LLM_GATEWAY_API_KEY
             CONTEXT7_API_KEY:coder-nt/CONTEXT7_API_KEY
             GH_PAT_FOR_MCP:coder-nt/GH_PAT_FOR_MCP
+            AGENTMEMORY_SECRET:coder-nt/AGENTMEMORY_SECRET
 
       - name: Sync providers / models / MCP servers / system prompt / template-allowlist
         run: ./coder-agents-config/sync.sh coder-agents-config

--- a/coder-agents-config/mcp-servers.yaml
+++ b/coder-agents-config/mcp-servers.yaml
@@ -74,7 +74,9 @@ mcp_servers:
     description: 'Per-project persistent memory: save observations, recall via smart search, list/audit sessions, manage lessons + sentinels. Always pass `project` derived from the repo (basename of `git remote get-url origin .git`) so memory scopes per repo and survives workspace recreate.'
     icon_url: /icon/database.svg
     transport: streamable_http
-    url: http://agentmemory:3114/mcp
-    auth_type: none
+    url: https://memory.tapiavala.com/mcp
+    auth_type: custom_headers
+    custom_headers:
+      Authorization: Bearer ${AGENTMEMORY_SECRET}
     enabled: true
     availability: default_on

--- a/host-services/agentmemory/README.md
+++ b/host-services/agentmemory/README.md
@@ -49,13 +49,14 @@ adapter container, no UUID resolution.
 | 3114  | MCP streamable_http bridge (`/mcp`)                |
 | 49134 | iii bridge (WebSocket — programmatic SDK access)   |
 
-agentmemory is **internal-only**: other host services (chatd, workspaces
-on `ubuntu_default`) reach it directly over the docker network at
-`http://agentmemory:3111` (REST) or `http://agentmemory:3114/mcp` (MCP).
-No Traefik labels, nothing public on the internet — the memory store
-doesn't need to be reachable from outside the host VM. The viewer (3113)
-is reachable from a laptop via SSH port-forward (`ssh -L 3113:agentmemory:3113 vm`)
-when needed.
+The MCP streamable_http bridge (3114) is exposed publicly at
+`https://memory.tapiavala.com/mcp` via Traefik, gated by Bearer auth.
+All clients — including chatd inside workspaces — use this URL with
+`Authorization: Bearer ${AGENTMEMORY_SECRET}`. One auth boundary, one
+threat model. The raw REST API (3111), stream WS (3112), viewer (3113),
+and iii bridge (49134) stay docker-network-only since no off-the-shelf
+client speaks those shapes. Viewer is reachable from a laptop via SSH
+port-forward (`ssh -L 3113:agentmemory:3113 vm`) when needed.
 
 ### Bind quirk (and why our entrypoint writes where it does)
 
@@ -153,41 +154,80 @@ docker exec -it agentmemory curl -fsS http://127.0.0.1:3111/agentmemory/health
 
 ## Wiring agents
 
-Two paths exist depending on what the agent's MCP client supports.
+Every MCP client — chatd, Claude Desktop, Cursor, in-workspace CLIs —
+uses the same public URL with the same Bearer token.
 
-### Coder Agents (chatd) — streamable_http MCP via the bridge
+### Authentication
 
-chatd only supports HTTP MCP transports. Upstream agentmemory only ships
-stdio MCP + custom REST endpoints, so a small Node bridge (`mcp-http-bridge.mjs`)
-baked into this image translates JSON-RPC → the upstream REST endpoints
-and exposes them on `:3114/mcp`.
+`AGENTMEMORY_SECRET` (set on the agentmemory container via host `.env`,
+pulled from GCP Secret Manager) gates every REST and MCP endpoint with
+`Authorization: Bearer <secret>`. Validated upstream via timing-safe
+HMAC comparison (`src/auth.ts`). The bridge on 3114 forwards inbound
+Authorization headers verbatim to the upstream REST calls, so the same
+secret protects both transports.
 
-Wired into Coder Agents via `coder-agents-config/mcp-servers.yaml`:
+Generate:
+
+```bash
+openssl rand -hex 32
+```
+
+Store in GCP Secret Manager (`coder-nt/AGENTMEMORY_SECRET`), reference
+from the host `.env`, and distribute the same value to every MCP client
+config that needs to call it.
+
+### Coder Agents (chatd) — streamable_http MCP
+
+Wired via `coder-agents-config/mcp-servers.yaml`:
 
 ```yaml
 - slug: agentmemory
   transport: streamable_http
-  url: http://agentmemory:3114/mcp
-  auth_type: none
+  url: https://memory.tapiavala.com/mcp
+  auth_type: custom_headers
+  custom_headers:
+    Authorization: Bearer ${AGENTMEMORY_SECRET}
 ```
 
-### Stdio MCP clients (Claude Desktop, Cursor, Codex, in-workspace CLIs)
+The `${AGENTMEMORY_SECRET}` placeholder is substituted at sync time by
+`coder-agents-config/sync.sh`, reading from the workflow env populated
+from GCP Secret Manager.
 
-Use the upstream stdio shim, pointed at the REST API:
+### Streamable-http MCP clients (any conforming client)
+
+Point at `https://memory.tapiavala.com/mcp`, add the Bearer header.
+Example for an MCP client that supports custom headers:
 
 ```json
 {
   "mcpServers": {
     "agentmemory": {
-      "command": "npx",
-      "args": ["-y", "@agentmemory/mcp"],
-      "env": {
-        "AGENTMEMORY_URL": "http://agentmemory:3111"
+      "transport": "streamable_http",
+      "url": "https://memory.tapiavala.com/mcp",
+      "headers": {
+        "Authorization": "Bearer <AGENTMEMORY_SECRET>"
       }
     }
   }
 }
 ```
+
+### Stdio MCP clients (Claude Desktop, Cursor, Codex)
+
+The upstream stdio shim (`@agentmemory/mcp`) calls the raw REST API on
+port 3111, which is **not** exposed publicly (only the streamable_http
+bridge on 3114 is). Two options:
+
+1. **Switch to streamable_http** (recommended) if the client supports
+   it — use the example above pointing at `https://memory.tapiavala.com/mcp`.
+2. **SSH tunnel** to port 3111 if you must use the stdio shim:
+
+   ```bash
+   ssh -L 3111:agentmemory:3111 vm
+   ```
+
+   then run the shim with `AGENTMEMORY_URL=http://127.0.0.1:3111` and
+   `AGENTMEMORY_SECRET=<secret>`.
 
 Either way, every `memory_*` call should include `project` derived from
 the workspace's git remote so memory is scoped per repo and survives

--- a/host-services/agentmemory/docker-compose.snippet.yml
+++ b/host-services/agentmemory/docker-compose.snippet.yml
@@ -1,18 +1,27 @@
 # Append this service to the host docker-compose on the Coder VM.
 #
-# agentmemory is the persistent memory backend that workspaces talk to via
-# the @agentmemory/mcp MCP server. Holds session observations, embeddings,
-# and lifecycle metadata across workspace recreate.
+# agentmemory is the persistent memory backend that any MCP client — chatd
+# inside workspaces, Claude Desktop, Cursor, in-workspace CLIs, etc. — can
+# talk to. Holds session observations, embeddings, and lifecycle metadata
+# across workspace recreate.
 #
 # Storage backend is chosen at startup by the bundled docker-entrypoint.sh:
 #   UPSTASH_REDIS_URL set in .env → Redis (state/stream/cron all on Upstash)
 #   UPSTASH_REDIS_URL unset       → file-based on /data named volume
 #
-# In our topology agentmemory is INTERNAL-ONLY: workspaces reach it over
-# the docker network at http://agentmemory:3111. No Traefik labels —
-# nothing on the public internet should be hitting the memory store
-# directly. If you need the viewer (3113) from a laptop, port-forward
-# via SSH or expose behind Traefik with auth.
+# Public access: the MCP streamable_http bridge (port 3114) is exposed via
+# Traefik at https://memory.tapiavala.com/mcp, gated by Bearer auth using
+# AGENTMEMORY_SECRET. ALL clients (including chatd inside workspaces) go
+# through this public URL with the same Bearer — one auth boundary, one
+# threat model. The raw REST API on 3111 and the streams/viewer ports stay
+# docker-network-only since no off-the-shelf client speaks those shapes.
+#
+# Required env in the host .env:
+#   AGENTMEMORY_SECRET  — Bearer token for every REST + MCP endpoint.
+#                         Generate with `openssl rand -hex 32` and pull
+#                         from GCP Secret Manager. Same value must be
+#                         configured on every MCP client
+#                         (`Authorization: Bearer <secret>`).
 #
 # Optional env in the host .env:
 #   UPSTASH_REDIS_URL  — full rediss:// URL from your Upstash console.
@@ -27,6 +36,12 @@ services:
     container_name: agentmemory
     restart: unless-stopped
     environment:
+      # Bearer secret. Setting this turns on upstream agentmemory's
+      # middleware::api-auth across every REST + MCP endpoint (verified in
+      # rohitg00/agentmemory src/triggers/api.ts + src/mcp/server.ts).
+      # The mcp-http-bridge forwards inbound Authorization headers verbatim,
+      # so the same secret protects port 3114 too.
+      AGENTMEMORY_SECRET: ${AGENTMEMORY_SECRET:?set in .env}
       # Empty default = file-based fallback. Set in .env to switch to Upstash.
       UPSTASH_REDIS_URL: ${UPSTASH_REDIS_URL:-}
     volumes:
@@ -36,7 +51,18 @@ services:
       # Redis paths just don't write there.
       - agentmemory-data:/data
     labels:
-      # Watchtower auto-update opt-in (no Traefik labels: internal-only).
+      - "traefik.enable=true"
+
+      # Only the MCP streamable_http bridge (3114) is exposed publicly.
+      # The REST API (3111), stream WS (3112), viewer (3113), and iii
+      # bridge (49134) stay docker-network-only — no off-the-shelf client
+      # speaks those shapes, and the viewer is reachable via SSH port
+      # forward when needed.
+      - "traefik.http.services.agentmemory.loadbalancer.server.port=3114"
+      - "traefik.http.routers.agentmemory.rule=Host(`memory.tapiavala.com`)"
+      - "traefik.http.routers.agentmemory.entrypoints=websecure"
+      - "traefik.http.routers.agentmemory.tls.certresolver=le"
+
       - "com.centurylinklabs.watchtower.enable=true"
 
 volumes:

--- a/host-services/agentmemory/mcp-http-bridge.mjs
+++ b/host-services/agentmemory/mcp-http-bridge.mjs
@@ -21,6 +21,11 @@
 //   prompts/list                   → GET  /agentmemory/mcp/prompts
 //   prompts/get                    → POST /agentmemory/mcp/prompts/get      {name, arguments}
 //
+// Auth: the inbound Authorization header is forwarded verbatim to every upstream
+// REST call. When AGENTMEMORY_SECRET is set on the upstream agentmemory process,
+// its middleware::api-auth validates `Authorization: Bearer <secret>` via
+// timingSafeCompare. The bridge does no auth itself; it is purely a translator.
+//
 // Streamable HTTP transport per spec rev 2025-03-26: a single POST to /mcp
 // returns either application/json (single response) or text/event-stream
 // (server-streamed responses). We only ever return single responses since
@@ -42,20 +47,21 @@ function log(...args) {
   process.stderr.write(`[mcp-http-bridge] ${args.join(" ")}\n`);
 }
 
-async function upstream(path, init = {}) {
-  const res = await fetch(`${UPSTREAM}${path}`, {
-    ...init,
-    headers: { "content-type": "application/json", ...(init.headers || {}) },
-  });
+async function upstream(path, init = {}, authHeader) {
+  const headers = { "content-type": "application/json", ...(init.headers || {}) };
+  if (authHeader) headers.authorization = authHeader;
+  const res = await fetch(`${UPSTREAM}${path}`, { ...init, headers });
   if (!res.ok) {
     const body = await res.text().catch(() => "");
-    throw new Error(`upstream ${path} ${res.status}: ${body.slice(0, 200)}`);
+    const err = new Error(`upstream ${path} ${res.status}: ${body.slice(0, 200)}`);
+    err.status = res.status;
+    throw err;
   }
   const text = await res.text();
   return text ? JSON.parse(text) : null;
 }
 
-async function dispatch(method, params) {
+async function dispatch(method, params, authHeader) {
   switch (method) {
     case "initialize":
       return {
@@ -76,7 +82,7 @@ async function dispatch(method, params) {
       return {};
 
     case "tools/list": {
-      const r = await upstream("/agentmemory/mcp/tools", { method: "GET" });
+      const r = await upstream("/agentmemory/mcp/tools", { method: "GET" }, authHeader);
       return { tools: Array.isArray(r?.tools) ? r.tools : [] };
     }
 
@@ -87,13 +93,13 @@ async function dispatch(method, params) {
           name: params?.name,
           arguments: params?.arguments || {},
         }),
-      });
+      }, authHeader);
       if (r && Array.isArray(r.content)) return { content: r.content, isError: !!r.isError };
       return { content: [{ type: "text", text: JSON.stringify(r) }] };
     }
 
     case "resources/list": {
-      const r = await upstream("/agentmemory/mcp/resources", { method: "GET" });
+      const r = await upstream("/agentmemory/mcp/resources", { method: "GET" }, authHeader);
       return { resources: Array.isArray(r?.resources) ? r.resources : [] };
     }
 
@@ -101,12 +107,12 @@ async function dispatch(method, params) {
       const r = await upstream("/agentmemory/mcp/resources/read", {
         method: "POST",
         body: JSON.stringify({ uri: params?.uri }),
-      });
+      }, authHeader);
       return { contents: Array.isArray(r?.contents) ? r.contents : [] };
     }
 
     case "prompts/list": {
-      const r = await upstream("/agentmemory/mcp/prompts", { method: "GET" });
+      const r = await upstream("/agentmemory/mcp/prompts", { method: "GET" }, authHeader);
       return { prompts: Array.isArray(r?.prompts) ? r.prompts : [] };
     }
 
@@ -117,7 +123,7 @@ async function dispatch(method, params) {
           name: params?.name,
           arguments: params?.arguments || {},
         }),
-      });
+      }, authHeader);
       return r;
     }
 
@@ -130,7 +136,7 @@ function isNotification(req) {
   return req.id === undefined || req.id === null;
 }
 
-async function handleMessage(req) {
+async function handleMessage(req, authHeader) {
   if (!req || typeof req !== "object" || req.jsonrpc !== "2.0" || typeof req.method !== "string") {
     return {
       jsonrpc: "2.0",
@@ -139,7 +145,7 @@ async function handleMessage(req) {
     };
   }
   try {
-    const result = await dispatch(req.method, req.params || {});
+    const result = await dispatch(req.method, req.params || {}, authHeader);
     if (isNotification(req)) return null;
     return { jsonrpc: "2.0", id: req.id, result };
   } catch (err) {
@@ -147,7 +153,7 @@ async function handleMessage(req) {
       log(`notification handler error for ${req.method}: ${err?.message || err}`);
       return null;
     }
-    const code = err?.code || -32603;
+    const code = err?.code || (err?.status === 401 ? -32001 : -32603);
     return {
       jsonrpc: "2.0",
       id: req.id,
@@ -190,6 +196,7 @@ const server = createServer(async (req, res) => {
       req.destroy();
     }
   });
+  const authHeader = req.headers.authorization || req.headers.Authorization;
   req.on("end", async () => {
     let parsed;
     try {
@@ -200,7 +207,7 @@ const server = createServer(async (req, res) => {
       return;
     }
     const messages = Array.isArray(parsed) ? parsed : [parsed];
-    const responses = (await Promise.all(messages.map(handleMessage))).filter(Boolean);
+    const responses = (await Promise.all(messages.map((m) => handleMessage(m, authHeader)))).filter(Boolean);
     if (responses.length === 0) {
       res.writeHead(202).end();
       return;


### PR DESCRIPTION
Makes the agentmemory MCP reachable by any client (not just docker-network siblings), gated by a shared Bearer secret.

## Topology
```
external client ─┐
                 ├─► Traefik (websecure, Host=memory.tapiavala.com)
                 │      └─► agentmemory:3114  (mcp-http-bridge)
                 │             └─► 127.0.0.1:3111  (upstream agentmemory, validates Bearer)
internal chatd ──┘
```
All clients — including chatd inside workspaces — go through `https://memory.tapiavala.com/mcp` with `Authorization: Bearer ${AGENTMEMORY_SECRET}`. One auth boundary, one threat model.

## Auth mechanism (upstream-native)
Upstream agentmemory (rohitg00/agentmemory) registers `middleware::api-auth` on every REST + MCP endpoint when `AGENTMEMORY_SECRET` is set on the process (`src/triggers/api.ts`, `src/mcp/server.ts`). Validation is timing-safe HMAC compare (`src/auth.ts`). No custom auth code in our image.

## Changes

| File | Change |
|---|---|
| `host-services/agentmemory/mcp-http-bridge.mjs` | Forward inbound `Authorization` header through `handleMessage` → `dispatch` → `upstream()` so upstream validates with the same Bearer the external client sent. |
| `host-services/agentmemory/docker-compose.snippet.yml` | Add `AGENTMEMORY_SECRET` env wiring + Traefik labels (route `memory.tapiavala.com` → port 3114). Header comment updated. |
| `host-services/agentmemory/README.md` | Topology, auth, and wiring docs for all three client types (chatd / streamable_http / stdio). |
| `coder-agents-config/mcp-servers.yaml` | agentmemory entry: `auth_type: none` + internal URL → `auth_type: custom_headers` + public URL + Bearer placeholder. |
| `.github/workflows/update-coder-agents-config.yaml` | Pull `AGENTMEMORY_SECRET` from GCP Secret Manager so `envsubst` substitutes it during sync. |
| `.github/SECRETS.md` | Document the new secret. |

## Public exposure scope
Only port 3114 (the streamable_http bridge) is behind Traefik. The raw REST API (3111), stream WS (3112), viewer (3113), and iii bridge (49134) stay docker-network-only — no off-the-shelf client speaks those shapes, and exposing them would widen the surface for no benefit. Stdio shim users (`@agentmemory/mcp`) need an SSH tunnel since the shim calls raw REST paths.

## Deploy checklist (host side)
1. `gcloud secrets create AGENTMEMORY_SECRET --project=coder-nt` and seed with `openssl rand -hex 32`.
2. Pull the new image to the VM.
3. Add `AGENTMEMORY_SECRET=<value>` to the host `.env`.
4. DNS `memory.tapiavala.com` → Traefik (same as other `*.tapiavala.com` subdomains).
5. `docker compose up -d agentmemory`.
6. `gh workflow run update-coder-agents-config.yaml` so chatd picks up the new URL + header.

## Verification
- `curl -i https://memory.tapiavala.com/mcp -X POST -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'` → 401
- Same call with `-H "Authorization: Bearer $AGENTMEMORY_SECRET"` → 200 with tools list
- Inside a fresh workspace, chatd shows agentmemory connected and `memory_recall` works
- `node --check` passes on the modified bridge