### PR TITLE
agentmemory: terminate Upstash TLS via in-container stunnel

### DIFF
--- a/host-services/agentmemory/Dockerfile
+++ b/host-services/agentmemory/Dockerfile
@@ -29,8 +29,13 @@ ARG TARGETARCH
 ARG III_VERSION=v0.11.2
 ARG AGENTMEMORY_VERSION=latest
 
+# stunnel4 terminates TLS for `rediss://` Upstash endpoints. iii's vendored
+# redis crate (v1.0.1) is built without `tls-rustls` / `tls-native-tls`, so
+# it cannot dial `rediss://` directly. The entrypoint starts stunnel
+# listening on 127.0.0.1:6379 and rewrites UPSTASH_REDIS_URL to a plain
+# `redis://...@127.0.0.1:6379` before iii reads its config.
 RUN apt-get update \
- && apt-get install -y --no-install-recommends curl ca-certificates tini \
+ && apt-get install -y --no-install-recommends curl ca-certificates tini stunnel4 \
  && rm -rf /var/lib/apt/lists/*
 
 # ── iii-engine binary (Rust, statically linked, includes rustls for TLS) ─────

--- a/host-services/agentmemory/README.md
+++ b/host-services/agentmemory/README.md
@@ -99,11 +99,19 @@ image rebuild.
 
 ### Verified constraints
 
-Probed against iii v0.11.2 source:
+Probed against iii source (v0.11.2 → v0.11.7-next.2 — all current releases):
 
-- TLS works out of the box. The published iii binary is built with `rustls`
-  (pulled in transitively by OpenTelemetry exporters even though
-  `engine/Cargo.toml` doesn't advertise the redis-rs TLS feature).
+- **TLS does NOT work out of the box.** iii's vendored `redis = "1.0.1"`
+  is declared with features `["tokio-comp", "connection-manager"]` — no
+  `tls-rustls` or `tls-native-tls`. The release binary physically cannot
+  dial `rediss://`. (My earlier note that the binary was built with
+  rustls was wrong: rustls symbols come from `reqwest` + `opentelemetry`,
+  not from the redis crate.) Upstash is TLS-only, so this image runs
+  `stunnel4` internally to bridge the gap (entrypoint listens on
+  `127.0.0.1:6379` and forwards to Upstash with TLS, then rewrites
+  `UPSTASH_REDIS_URL` to the plain-tcp local endpoint before iii starts).
+  No host-side change required — just set `UPSTASH_REDIS_URL` to the
+  `rediss://` URL from your Upstash console.
 - All three workers (state, stream, cron) accept exactly one config key:
   `redis_url`. No pool/timeout/db-number knobs.
 - iii-stream holds a persistent SUBSCRIBE connection — counts against

--- a/host-services/agentmemory/docker-entrypoint.sh
+++ b/host-services/agentmemory/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # agentmemory entrypoint.
 #
-# Two responsibilities:
+# Three responsibilities:
 #
 # 1) Install the right iii-engine config so the worker actually reads it.
 #
@@ -16,13 +16,24 @@
 #    UPSTASH_REDIS_URL set + non-empty → Redis (cross-host durable state)
 #    unset / empty                     → file-based (local volume)
 #
-# 2) Start the MCP-over-HTTP bridge alongside the agentmemory worker.
+# 2) Terminate TLS for Upstash via in-container stunnel.
+#
+#    iii's vendored redis-rs (v1.0.1, resolved to 1.2.0) is built without
+#    `tls-rustls`/`tls-native-tls` features (verified in iii-hq/iii's
+#    engine/Cargo.toml across every tagged release including v0.11.7-next.2),
+#    so it physically cannot dial `rediss://`. Upstash only offers TLS for
+#    the redis wire protocol. We parse the user's `rediss://` URL, point
+#    stunnel at the upstream host, listen plain TCP on 127.0.0.1:6379, and
+#    hand iii a rewritten `redis://...@127.0.0.1:6379` URL. The AUTH
+#    password flows verbatim inside the TLS tunnel.
+#
+# 3) Start the MCP-over-HTTP bridge alongside the agentmemory worker.
 #
 #    Upstream only ships stdio MCP + custom REST endpoints under
 #    /agentmemory/mcp/*. Coder Agents (chatd) speaks streamable_http MCP, so we
 #    background a tiny Node bridge that translates JSON-RPC → those REST
-#    endpoints. SIGTERM/INT is trapped so both processes stop together when
-#    `docker stop` propagates the signal through tini.
+#    endpoints. SIGTERM/INT is trapped so all background processes stop
+#    together when `docker stop` propagates the signal through tini.
 
 set -eu
 
@@ -30,9 +41,52 @@ CONFIG_DIR="/opt/agentmemory-config"
 TARGET="$(npm root -g)/@agentmemory/agentmemory/dist/iii-config.yaml"
 mkdir -p "$(dirname "$TARGET")"
 
+STUNNEL_PID=""
+
 if [ -n "${UPSTASH_REDIS_URL:-}" ]; then
   echo "[agentmemory] UPSTASH_REDIS_URL set — using Upstash Redis backend"
   cp "${CONFIG_DIR}/iii-config.upstash.yaml" "${TARGET}"
+
+  # Parse rediss://user:pass@host:port — strip scheme, split on @ for creds,
+  # split host:port. POSIX-compatible parameter expansion; works in dash.
+  url_no_scheme="${UPSTASH_REDIS_URL#*://}"
+  case "$url_no_scheme" in
+    *@*)
+      creds="${url_no_scheme%@*}"
+      hostport="${url_no_scheme##*@}"
+      ;;
+    *)
+      creds=""
+      hostport="$url_no_scheme"
+      ;;
+  esac
+  upstream_host="${hostport%:*}"
+  upstream_port="${hostport##*:}"
+  case "$hostport" in *:*) ;; *) upstream_port=6379 ;; esac
+
+  cat > /etc/stunnel/upstash.conf <<EOF
+foreground = yes
+output = /dev/stderr
+pid =
+[redis]
+client = yes
+accept = 127.0.0.1:6379
+connect = ${upstream_host}:${upstream_port}
+verify = 2
+CAfile = /etc/ssl/certs/ca-certificates.crt
+sni = ${upstream_host}
+EOF
+
+  stunnel /etc/stunnel/upstash.conf &
+  STUNNEL_PID=$!
+  echo "[agentmemory] stunnel → ${upstream_host}:${upstream_port} (pid $STUNNEL_PID)"
+
+  if [ -n "$creds" ]; then
+    UPSTASH_REDIS_URL="redis://${creds}@127.0.0.1:6379"
+  else
+    UPSTASH_REDIS_URL="redis://127.0.0.1:6379"
+  fi
+  export UPSTASH_REDIS_URL
 else
   echo "[agentmemory] UPSTASH_REDIS_URL unset — using local file-based backend at /data"
   cp "${CONFIG_DIR}/iii-config.file-based.yaml" "${TARGET}"
@@ -40,6 +94,6 @@ fi
 
 node /usr/local/bin/mcp-http-bridge.mjs &
 BRIDGE_PID=$!
-trap 'kill -TERM "$BRIDGE_PID" 2>/dev/null || true' EXIT TERM INT
+trap 'kill -TERM "$BRIDGE_PID" "$STUNNEL_PID" 2>/dev/null || true' EXIT TERM INT
 
 exec "$@"

--- a/host-services/agentmemory/iii-config.upstash.yaml
+++ b/host-services/agentmemory/iii-config.upstash.yaml
@@ -10,11 +10,21 @@
 #   engine/src/workers/stream/adapters/redis_adapter.rs:430  (same)
 #   engine/src/workers/cron/adapters/redis_adapter.rs:64     (same)
 #
-# TLS: published iii binary IS built with rustls (verified by inspecting
-# `strings $(which iii)` for rustls-0.23.x symbols), pulled in
-# transitively via the OpenTelemetry exporters even though Cargo.toml
-# doesn't advertise the redis-rs TLS feature explicitly. Upstash
-# `rediss://` URLs work out of the box.
+# TLS: the published iii binary is NOT linked against TLS for the redis
+# crate. Verified in iii-hq/iii engine/Cargo.toml across every release
+# (v0.11.2 → v0.11.7-next.2):
+#   redis = { version = "1.0.1", features = ["tokio-comp", "connection-manager"] }
+# No `tls-rustls` / `tls-native-tls`. rustls symbols in the binary come
+# from reqwest + opentelemetry-otlp, which don't help the redis client.
+# Symptom if iii hits a `rediss://` directly: worker iii-state fails
+# with `can't connect with TLS, the feature is not enabled - InvalidClientConfig`.
+#
+# Workaround: docker-entrypoint.sh runs an in-container stunnel that
+# accepts plain TCP on 127.0.0.1:6379 and forwards to the Upstash host
+# with TLS. It rewrites UPSTASH_REDIS_URL to `redis://...@127.0.0.1:6379`
+# before iii reads this file, so `${UPSTASH_REDIS_URL}` below resolves
+# to the local plain-text endpoint. The Upstash AUTH password rides
+# inside the stunnel TLS tunnel — never on the public network in clear.
 #
 # Constraints to be aware of (none are showstoppers for solo use):
 #   - Persistent SUBSCRIBE connection from iii-stream burns one of


### PR DESCRIPTION
## Bug

After PR #59 fixed the iii-config bind path, Upstash actually engages on container start — and the iii engine immediately crashes:

```
Error: failed to create worker 'iii-state': Failed to create iii-state:
can't connect with TLS, the feature is not enabled - InvalidClientConfig
```

## Root cause

iii's vendored `redis` crate is declared without TLS feature flags. From `iii-hq/iii engine/Cargo.toml` (line 119, verified identical across every tag from `v0.11.2` through `v0.11.7-next.2`):

```toml
redis = { version = "1.0.1", features = ["tokio-comp", "connection-manager"] }
```

Missing `tls-rustls` / `tls-native-tls` → the release binary physically cannot dial `rediss://`. The `rustls` symbols visible via `strings` come from `reqwest` + `opentelemetry-otlp`, which don't help the redis client. My earlier README claim that "TLS works out of the box" was wrong.

Upstash only offers TLS for the redis wire protocol (`rediss://`); their REST API is a different protocol entirely and is not what iii speaks.

## Fix (no fork, no sidecar)

Bake `stunnel4` into the image. The entrypoint:

1. Parses the user's `rediss://default:PASSWORD@host:port` URL.
2. Writes `/etc/stunnel/upstash.conf` targeting that host:port with `verify = 2` + Debian's CA bundle.
3. Starts stunnel listening on `127.0.0.1:6379`.
4. Rewrites `UPSTASH_REDIS_URL` to `redis://default:PASSWORD@127.0.0.1:6379` and exports it.
5. `exec`s the agentmemory CLI, which reads the rewritten URL via iii's env-var substitution in `engine/src/workers/config.rs:56`.

The AUTH password rides inside the stunnel TLS tunnel — never on the public network in clear. Trap handler now signals both stunnel and the MCP bridge on container stop.

## Files changed

| File | Change |
|---|---|
| `Dockerfile` | `apt-get install ... stunnel4` |
| `docker-entrypoint.sh` | URL parsing, stunnel config gen, background launch, URL rewrite + export, trap update |
| `iii-config.upstash.yaml` | Corrected the TLS comment (was: "works out of the box"; now: documents why iii can't speak TLS and how stunnel bridges it) |
| `README.md` | Same correction in the "Verified constraints" section |

## Verification

Local sh test against the user's real Upstash URL produced the expected parse:
```
host=proper-ghoul-37794.upstash.io port=6379
rewritten=redis://default:<password>@127.0.0.1:6379
```

## Deploy

1. Rebuild + push image (existing `build-agentmemory.yaml` workflow does this on merge to main).
2. `docker compose pull agentmemory && docker compose up -d agentmemory` on the host.
3. No `.env` change; the same `UPSTASH_REDIS_URL=rediss://...` keeps working.