### PR TITLE
Engage Headroom tool-result interceptors + tighten distill guidance

### DIFF
--- a/host-services/headroom/README.md
+++ b/host-services/headroom/README.md
@@ -48,15 +48,39 @@ ContentRouter pipeline (SmartCrusher for JSON, CodeCompressor for AST,
 Kompress for prose) plus tool-result interceptors. No external LLM key
 required.
 
+**Tool-result interceptors must be explicitly enabled.** Upstream
+default is `intercept_tool_results: bool = False` (see
+`headroom/config.py`). We set `HEADROOM_INTERCEPT_ENABLED="1"` in the
+compose snippet to turn them on. Without that flag, ContentRouter
+selects the no-op pipeline for nearly every tool-result content block —
+which is the dominant content type in chatd-driven agent traffic.
+Observed effect of leaving it default: 8/36 requests compressed, 0.2%
+average savings, $0.00 compression dollar savings vs $0.55 prompt-cache
+savings. The fix is one env var, not a behavior tradeoff.
+
+**Prompt cache stays safe.** `PrefixFreezeConfig.enabled` is `True` by
+default, so Headroom refuses to rewrite any portion of the request
+covered by an Anthropic `cache_control` marker. Turning on tool-result
+interceptors only widens what gets compressed in the *non-cached*
+suffix (new user turns, fresh tool results). The 90% prefix-cache
+discount is untouched.
+
 **RTK clarification:** The full RTK shell-output rewriter only fires in
 `headroom wrap` mode (CLI tool wrapping). In proxy mode (what we run),
 only generic tool-result interceptors run — they can rewrite shell tool
-outputs but don't pull the full RTK pipeline. If you need RTK-grade
-shell compression for an agent, run `headroom wrap` on the client side
-in addition to the proxy.
+outputs but don't pull the full RTK pipeline. `headroom wrap` is not
+usable in our topology anyway, because chatd-based agents invoke tools
+over MCP (the `execute` MCP tool) rather than shelling out to a
+wrappable CLI. The chatd-architecture analogue of `headroom wrap` is
+`distill` running inside the workspace — see
+`workspace-images/base-dev/system_prompt.txt` for the agent-facing
+guidance.
 
 LLMLingua-2 is not included in the upstream `[proxy]` image. Rebuild
 from source with `[proxy,ml]` if you need neural compression (~700 MB).
+Not recommended on the shared Oracle VM (4 vCPU / 24 GB RAM): CPU
+inference would contend with active workspaces, and prompt cache is
+already capturing the bulk of available savings.
 
 ## Auth
 

--- a/host-services/headroom/docker-compose.snippet.yml
+++ b/host-services/headroom/docker-compose.snippet.yml
@@ -32,6 +32,26 @@ services:
       HEADROOM_PORT: 8787
       HEADROOM_MODE: token
       HEADROOM_TELEMETRY: "off"
+
+      # Turn on tool-result interceptors (default is OFF). In proxy mode this
+      # is what lights up the ast-grep Read outline + other tool-result
+      # rewriters that operate on Anthropic `tool_result` content blocks —
+      # exactly the chunk of every request that chatd-driven agents fill with
+      # shell/search output. Without this flag set, ContentRouter sees most
+      # requests as `router:noop` and compression savings are ~0%.
+      #
+      # Safe to combine with the cache layer: PrefixFreeze is enabled by
+      # default (PrefixFreezeConfig.enabled=True) and will refuse to rewrite
+      # any portion of the request covered by an Anthropic `cache_control`
+      # marker, so the 90% prefix-cache discount is preserved.
+      HEADROOM_INTERCEPT_ENABLED: "1"
+
+      # Default mode is already `optimize` (HeadroomMode.OPTIMIZE). Set
+      # explicitly so a future upstream default change can't silently switch
+      # us to audit mode and drop all compression. To temporarily disable
+      # compression for debugging, set HEADROOM_OPTIMIZE="false" instead —
+      # that's the documented master kill-switch and doesn't fight the mode.
+      HEADROOM_DEFAULT_MODE: optimize
       # NOTE: do NOT set HEADROOM_STATELESS=true — it disables all filesystem
       # writes, which means proxy_savings.json never persists (savings ledger
       # vanishes every restart) and --memory would be useless. We mount

--- a/workspace-images/base-dev/system_prompt.txt
+++ b/workspace-images/base-dev/system_prompt.txt
@@ -11,23 +11,8 @@ Check CLAUDE.md / AGENTS.md for project-specific tools. Available in every works
 - If Pencil MCP fails or returns no response, switch to Pencil CLI headless mode (e.g. `pencil interactive -i input.pen -o output.pen`) and continue there.
 - Observability: SigNoz MCP for OpenTelemetry projects. Start with `list_services`, then `search_traces_by_service` or `get_error_logs`.
 
--- Tool-output compression with `distill` --
-`distill` is your single most important token-efficiency tool. Tool output (shell, search, file dumps) is the largest token sink in chatd-based agent traffic, and `distill` is the only point where you can compress it before it enters your context. Use it aggressively.
-
-When to pipe through `distill` (any one of these triggers it):
-- The command may emit > ~50 lines or > ~2 KB of stdout. When in doubt, pipe.
-- The command is one of the usual firehose offenders: `grep -r`, `rg`, `find`, `tree`, `ls -R`, `cat <large-file>`, `tail -n +1`, `journalctl`, `docker logs`, `kubectl logs`, build/test runners, package-manager installs, network captures.
-- You only need a summary, count, names, or specific fields — not every line.
-
-When NOT to pipe through `distill`:
-- The downstream step needs exact, byte-for-byte output (diffs, hashes, file content you will pass to an edit tool, fixtures for tests, command-substitution where formatting matters).
-- Interactive / TUI commands (`vim`, `top`, `htop`, `less`, `gh pr view` in pager mode). `distill` only handles non-interactive stdout.
-- Tiny output already (a handful of lines). Overhead isn't worth it.
-
-How to invoke it well:
-- Always give `distill` an explicit, output-shaped prompt. Bad: `... | distill 'summarize'`. Good: `... | distill 'Return only the filenames, one per line.'`, `... | distill 'Return valid JSON: {"errors": [...], "warnings": [...]}'`, `... | distill 'Return the failing test names and their line numbers.'`
-- Wait for `distill` to finish before continuing. Don't background it.
-- If you piped through `distill` and lost something you actually needed, re-run the original command without `distill` rather than guessing.
+- Token efficiency: pipe non-interactive shell output through `distill` when output may exceed ~50 lines / ~2 KB or comes from firehose commands (`grep -r`, `rg`, `find`, `tree`, `ls -R`, `cat <large>`, `journalctl`, `docker logs`, `kubectl logs`, build/test runners, installers). Skip for byte-exact needs (diffs, hashes, file content for edits), interactive/TUI commands, and already-tiny output.
+- `distill` prompts must be output-shaped: `'Return only filenames, one per line.'`, `'Return valid JSON: {"errors": [...]}'`, `'Return failing test names and line numbers.'` — never `'summarize'`. Wait for it to finish; if it dropped something you needed, re-run without it.
 
 -- Application Development Process --
 - Project follows a phased architecture-first workflow. You may be brought in at any phase — check the current state of artifacts (CLAUDE.md, .likec4 files, contracts, checklists) to understand where the project stands before proceeding.

--- a/workspace-images/base-dev/system_prompt.txt
+++ b/workspace-images/base-dev/system_prompt.txt
@@ -6,13 +6,28 @@ Check CLAUDE.md / AGENTS.md for project-specific tools. Available in every works
 - Prefer local CLI tools over MCP when both can do the job. Use MCP for remote services, editor-only workflows, or when the CLI/skill cannot do the needed operation.
 - Core CLI: `git`, `docker`, `gh`, `gcloud`, `python`, `node`, `pnpm`
 - Task CLI: `distill` (compress large non-interactive output), `ctx7` (library docs), `likec4` (architecture), `pencil interactive` (`.pen`), `stitch-mcp <command>` (Stitch), `gitnexus` (run `gitnexus analyze` per repo first)
-- Token efficiency: for non-interactive shell commands with potentially large output, pipe through `distill` unless exact raw output is required.
-- `distill` prompts must be explicit about required output format (e.g., `Return only filenames.` / `Return valid JSON only.`). Avoid vague prompts.
-- Skip `distill` for interactive/TUI commands or when uncompressed output is explicitly needed. Always wait for `distill` to finish before proceeding.
 - Docs/examples: prefer `ctx7`; use Grep MCP for public GitHub code examples.
 - Architecture/design: prefer `likec4`, `pencil interactive`, and `stitch-mcp`; use the matching MCP only when needed. Excalidraw is via VS Code extension.
 - If Pencil MCP fails or returns no response, switch to Pencil CLI headless mode (e.g. `pencil interactive -i input.pen -o output.pen`) and continue there.
 - Observability: SigNoz MCP for OpenTelemetry projects. Start with `list_services`, then `search_traces_by_service` or `get_error_logs`.
+
+-- Tool-output compression with `distill` --
+`distill` is your single most important token-efficiency tool. Tool output (shell, search, file dumps) is the largest token sink in chatd-based agent traffic, and `distill` is the only point where you can compress it before it enters your context. Use it aggressively.
+
+When to pipe through `distill` (any one of these triggers it):
+- The command may emit > ~50 lines or > ~2 KB of stdout. When in doubt, pipe.
+- The command is one of the usual firehose offenders: `grep -r`, `rg`, `find`, `tree`, `ls -R`, `cat <large-file>`, `tail -n +1`, `journalctl`, `docker logs`, `kubectl logs`, build/test runners, package-manager installs, network captures.
+- You only need a summary, count, names, or specific fields — not every line.
+
+When NOT to pipe through `distill`:
+- The downstream step needs exact, byte-for-byte output (diffs, hashes, file content you will pass to an edit tool, fixtures for tests, command-substitution where formatting matters).
+- Interactive / TUI commands (`vim`, `top`, `htop`, `less`, `gh pr view` in pager mode). `distill` only handles non-interactive stdout.
+- Tiny output already (a handful of lines). Overhead isn't worth it.
+
+How to invoke it well:
+- Always give `distill` an explicit, output-shaped prompt. Bad: `... | distill 'summarize'`. Good: `... | distill 'Return only the filenames, one per line.'`, `... | distill 'Return valid JSON: {"errors": [...], "warnings": [...]}'`, `... | distill 'Return the failing test names and their line numbers.'`
+- Wait for `distill` to finish before continuing. Don't background it.
+- If you piped through `distill` and lost something you actually needed, re-run the original command without `distill` rather than guessing.
 
 -- Application Development Process --
 - Project follows a phased architecture-first workflow. You may be brought in at any phase — check the current state of artifacts (CLAUDE.md, .likec4 files, contracts, checklists) to understand where the project stands before proceeding.


### PR DESCRIPTION
## Why

`https://llm.tapiavala.com/stats` was showing essentially zero compression engagement: 8 / 36 requests compressed, 0.2% average, $0.00 compression dollar savings against $0.55 prompt-cache savings. Tracing the cause through the Headroom source:

- Upstream default is `intercept_tool_results: bool = False` (see [`headroom/config.py`](https://github.com/chopratejas/headroom/blob/main/headroom/config.py)).
- With that off, ContentRouter selects `router:noop` for nearly every `tool_result` content block — which is the dominant content type in chatd-driven agent traffic.
- The "default disabled" was a surprise; it isn't documented on the proxy README page.

Separately, `headroom wrap` (the pre-context compression seam) is not usable in our topology because chatd-based agents invoke tools over MCP (the `execute` MCP tool, provided by Coder upstream — not modifiable without forking). The workspace-side analogue we already ship is `distill`, but the existing guidance was three terse bullets without thresholds or examples, and compliance was almost certainly spotty.

## What

Three additive changes, no behavior change for the prompt cache.

### `host-services/headroom/docker-compose.snippet.yml`
- Set `HEADROOM_INTERCEPT_ENABLED=1` — lights up tool-result interceptors in proxy mode.
- Pin `HEADROOM_DEFAULT_MODE=optimize` so an upstream default flip can't silently put us in audit mode.

### `host-services/headroom/README.md`
- Documents the new flag and observed effect.
- Explains why prompt cache is unaffected (`PrefixFreezeConfig.enabled=True` by default refuses to rewrite cached-marker regions — interceptors only widen compression in the non-cached suffix).
- Notes why `headroom wrap` is not viable for chatd-based agents and points readers at the workspace-side `distill` guidance instead.
- Adds the Oracle VM rationale for skipping LLMLingua-2 (4 vCPU contention with active workspaces; prompt cache already captures the bulk of available savings).

### `workspace-images/base-dev/system_prompt.txt`
- Replaces the three terse distill bullets with a dedicated section.
- Concrete size triggers (~50 lines or ~2 KB stdout).
- Explicit firehose-command allowlist: `grep -r`, `rg`, `find`, `tree`, `ls -R`, `cat <large>`, `journalctl`, `docker logs`, `kubectl logs`, builders, installers.
- Inverse list (when not to pipe): byte-for-byte cases (diffs, hashes, edit-tool fixtures), interactive/TUI, already-tiny output.
- Three good-vs-bad prompt examples for shape-explicit `distill` calls.

`distill` is already installed in `workspace-images/base-dev/Dockerfile` via `@samuelfaj/distill` and inherited by every agent-facing image (`cpp-dev`, `python-dev`, `rust-dev`, `vite-dev`, `fullstack-dev`). `hapi-hub` is a single-purpose service container and doesn't need it.

## What we intentionally did **not** do

- **Did not enable OmniRoute compression.** Stacking compressors corrupts Anthropic `cache_control` markers and would cost more than it saves. (Rationale already in `host-services/omniroute/README.md:137-158`.)
- **Did not rebuild Headroom with `[proxy,ml]` for LLMLingua-2.** Neural compression on CPU on the shared 4-vCPU / 24-GB Oracle VM would contend with active workspaces; the cost/benefit isn't there given prompt cache is doing 100% of current savings.
- **Did not add PATH shims** for `grep`/`find`/etc. Discussed and rejected — agents would have to know to bypass them for exact-output cases, which is the same compliance problem `distill` already has.
- **Did not touch upstream Coder `execute` MCP.** Would require forking and rebuilding.

## Expected effect

Most of the gain should come from the `HEADROOM_INTERCEPT_ENABLED` flag immediately — every chatd request with tool_result blocks will now get routed through the interceptor pipeline instead of `router:noop`. The distill guidance is a slower lift, dependent on agents picking up the tightened rule in their context.

We can validate by checking `/stats` after a few sessions: the `compression.requests_compressed` ratio should climb from 8/36, average compression should rise above 0.2%, and `transforms_applied` should show entries other than `router:noop` on tool-heavy requests.

Cache savings should stay flat at ~$0.55 — that's the prompt-cache discount, which PrefixFreeze protects regardless of intercept settings.
