### PR TITLE
ci: auto-trigger image rebuilds on upstream releases (+ cliproxy v6.10.9 → v7.1.6)

### DIFF
--- a/.github/workflows/check-upstream-releases.yaml
+++ b/.github/workflows/check-upstream-releases.yaml
@@ -1,0 +1,96 @@
+name: Check upstream releases and trigger image rebuilds
+
+on:
+  schedule:
+    # Run daily at 06:00 UTC
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  check-cliproxy:
+    name: Check CLIProxyAPI release
+    runs-on: ubuntu-latest
+    outputs:
+      updated: ${{ steps.compare.outputs.updated }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch latest CLIProxyAPI release
+        id: upstream
+        run: |
+          LATEST=$(curl -fsSL \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/router-for-me/CLIProxyAPI/releases/latest" \
+            | jq -r '.tag_name')
+          echo "version=$LATEST" >> "$GITHUB_OUTPUT"
+
+      - name: Compare with current pinned version
+        id: compare
+        run: |
+          CURRENT=$(grep -oP '(?<=ARG CLI_PROXY_API_VERSION=)\S+' host-services/cliproxy/Dockerfile)
+          LATEST="${{ steps.upstream.outputs.version }}"
+          echo "Current: $CURRENT  Latest: $LATEST"
+          if [ "$CURRENT" != "$LATEST" ]; then
+            echo "updated=true" >> "$GITHUB_OUTPUT"
+            echo "new_version=$LATEST" >> "$GITHUB_OUTPUT"
+          else
+            echo "updated=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump version in Dockerfile and commit
+        if: steps.compare.outputs.updated == 'true'
+        run: |
+          NEW="${{ steps.compare.outputs.new_version }}"
+          sed -i "s|^ARG CLI_PROXY_API_VERSION=.*|ARG CLI_PROXY_API_VERSION=${NEW}|" \
+            host-services/cliproxy/Dockerfile
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add host-services/cliproxy/Dockerfile
+          git commit -m "chore(cliproxy): bump CLIProxyAPI to ${NEW} [skip ci on other paths]"
+          git push
+
+  check-agentmemory:
+    name: Check @agentmemory/agentmemory npm release
+    runs-on: ubuntu-latest
+    outputs:
+      updated: ${{ steps.compare.outputs.updated }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch latest @agentmemory/agentmemory version from npm
+        id: upstream
+        run: |
+          LATEST=$(curl -fsSL "https://registry.npmjs.org/@agentmemory/agentmemory/latest" \
+            | jq -r '.version')
+          echo "version=$LATEST" >> "$GITHUB_OUTPUT"
+
+      - name: Compare with current pinned version
+        id: compare
+        run: |
+          # Extract the pinned version (may be "latest" on first run or a semver)
+          CURRENT=$(grep -oP '(?<=ARG AGENTMEMORY_VERSION=)\S+' host-services/agentmemory/Dockerfile)
+          LATEST="v${{ steps.upstream.outputs.version }}"
+          echo "Current: $CURRENT  Latest: $LATEST"
+          if [ "$CURRENT" != "$LATEST" ]; then
+            echo "updated=true" >> "$GITHUB_OUTPUT"
+            echo "new_version=$LATEST" >> "$GITHUB_OUTPUT"
+            echo "npm_version=${{ steps.upstream.outputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "updated=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump version in Dockerfile and commit
+        if: steps.compare.outputs.updated == 'true'
+        run: |
+          NEW_NPM="${{ steps.compare.outputs.npm_version }}"
+          NEW_TAG="${{ steps.compare.outputs.new_version }}"
+          sed -i "s|^ARG AGENTMEMORY_VERSION=.*|ARG AGENTMEMORY_VERSION=${NEW_NPM}|" \
+            host-services/agentmemory/Dockerfile
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add host-services/agentmemory/Dockerfile
+          git commit -m "chore(agentmemory): bump @agentmemory/agentmemory to ${NEW_TAG}"
+          git push

--- a/host-services/cliproxy/Dockerfile
+++ b/host-services/cliproxy/Dockerfile
@@ -18,7 +18,7 @@ ARG TARGETARCH
 
 # Pin the upstream release. Bump in PRs and let watchtower roll the new
 # image out — no runtime version drift on the VM.
-ARG CLI_PROXY_API_VERSION=v6.10.9
+ARG CLI_PROXY_API_VERSION=v7.1.6
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends curl ca-certificates tini \

--- a/host-services/cliproxy/config.yaml
+++ b/host-services/cliproxy/config.yaml
@@ -11,7 +11,7 @@
 host: "0.0.0.0"
 port: 8317
 
-# OAuth credentials volume. Bootstrap once per provider. CLIProxyAPI v6.10.9
+# OAuth credentials volume. Bootstrap once per provider. CLIProxyAPI
 # does NOT expose an --auth-dir flag; pass --config and it reads this
 # auth-dir setting. It exposes provider-specific flags for Codex/Claude,
 # and generic --login for Gemini:


### PR DESCRIPTION
## What

1. **New workflow `.github/workflows/check-upstream-releases.yaml`** — runs daily at 06:00 UTC (plus manual dispatch) and:
   - Checks the latest release of `router-for-me/CLIProxyAPI` on GitHub.
   - Checks the latest version of `@agentmemory/agentmemory` on npm.
   - If either differs from the value pinned in our Dockerfile's `ARG …_VERSION=` line, it bumps the ARG and commits to `main`. That commit lands in `host-services/cliproxy/**` or `host-services/agentmemory/**`, which fires the existing `build-cliproxy.yaml` / `build-agentmemory.yaml` workflows via their existing `paths:` filter.
   - This means the existing trigger on changes to our own Dockerfile / build extension files is preserved exactly — we just added a second mechanism that also touches those files when upstream cuts a release.

2. **Bump `CLI_PROXY_API_VERSION` v6.10.9 → v7.1.6.** Before bumping I checked every v7.x release note. Two auth-related changes:
   - `refactor(cliproxy): remove ClaudeCodeSessionAffinity support` — not used anywhere in this repo (`grep` returns zero hits).
   - `fix: apply default auth-dir when config value is empty` — our `config.yaml` sets `auth-dir: "/data/auth/cliproxy"` explicitly, so default behavior is irrelevant.
   - As a bonus, v7 also brings in (carried from late v6) `dedupe Claude OAuth refresh + honor 429 backoff` and `improve unauthorized error handling for refresh/auto-refresh` — net positive for Claude Code subscription stability.
   - Also dropped the now-stale `v6.10.9` literal from a config.yaml comment.

3. **`III_VERSION` in agentmemory intentionally left alone.** The Dockerfile comment is explicit that v0.11.6+ requires an upstream refactor in agentmemory to be compatible. The poller only touches `AGENTMEMORY_VERSION`, not `III_VERSION`.

## Side benefit
After the first poll run, `AGENTMEMORY_VERSION=latest` will be replaced with a pinned semver, making agentmemory builds reproducible.

## Risk
- The bot commits directly to `main`. If you'd rather it open a PR for review per bump, easy follow-up.
- Major version bumps will sail through unattended. For cliproxy specifically we've already reviewed v7; future major bumps (v8+) would also go unreviewed unless we add a guard.
