### PR TITLE
Forward coder_agent.env into envbuilder container env

### DIFF
--- a/workspace-modules/workspace-envbuilder/main.tf
+++ b/workspace-modules/workspace-envbuilder/main.tf
@@ -29,7 +29,10 @@ locals {
     exit 0
   EOT
 
-  envbuilder_env = merge({
+  # Order: agent_env first so envbuilder/coder-token keys (which the
+  # module owns) win on conflict, then the is_new_project flags last
+  # so they're authoritative for that workspace lifecycle state.
+  envbuilder_env = merge(var.agent_env, {
     "CODER_AGENT_TOKEN"               = var.agent_token
     "CODER_AGENT_URL"                 = replace(var.access_url, "/localhost|127\\.0\\.0\\.1/", "host.docker.internal")
     "ENVBUILDER_SETUP_SCRIPT"         = local.envbuilder_setup_script

--- a/workspace-modules/workspace-envbuilder/variables.tf
+++ b/workspace-modules/workspace-envbuilder/variables.tf
@@ -38,3 +38,16 @@ variable "devcontainer_builder_image" {
   type    = string
   default = "ghcr.io/coder/envbuilder:latest"
 }
+
+# Map of environment variables declared on coder_agent.main.env. Forwarded
+# into the envbuilder-built container so they land on the workspace's
+# `coder agent` process at exec time. This matters for any agent config
+# the agent reads from its own os.Getenv at startup (e.g.
+# CODER_AGENT_EXP_SKILLS_DIRS, CODER_AGENT_EXP_INSTRUCTIONS_DIRS) —
+# those are NOT delivered via the manifest's EnvironmentVariables, which
+# the agent only applies to child processes (SSH sessions, scripts),
+# not to itself.
+variable "agent_env" {
+  type    = map(string)
+  default = {}
+}

--- a/workspace-templates/project-workspace/main.tf
+++ b/workspace-templates/project-workspace/main.tf
@@ -193,6 +193,7 @@ module "workspace_envbuilder" {
   is_new_project             = local.is_new_project
   fallback_image             = "ghcr.io/nyc-design/workspace-images/base-dev:latest"
   devcontainer_builder_image = "ghcr.io/coder/envbuilder:latest"
+  agent_env                  = coder_agent.main.env
 }
 
 module "workspace_apps_metadata" {


### PR DESCRIPTION
## Problem

Skills placed in `~/.agents/skills` weren't being picked up by Coder Agents chats, even though the workspace template sets `CODER_AGENT_EXP_SKILLS_DIRS="~/.agents/skills,.agents/skills"` in `coder_agent.main.env`.

## Root cause

Two facts about Coder's agent that together produce the bug:

1. The chat agent (chatd) does not read skill env vars itself. It fetches skills over dRPC from the workspace agent via `conn.ContextConfig(...)`.
2. The workspace agent resolves skills/instructions/MCP config at **startup** via `agentcontextconfig.ReadEnvConfig()` (`cli/agent.go`), which reads directly from `os.Getenv` on the agent process. The manifest-level `EnvironmentVariables` (i.e. `coder_agent.env`) is only merged into the env of **child processes** the agent spawns (SSH sessions, scripts) via `updateCommandEnv` in `agent/agent.go`. It is never re-exported into the agent's own process env.

Verified empirically:

```
$ cat /proc/1/environ   | tr '\\0' '\\n' | grep -E 'GIT_AUTHOR|CODER_AGENT_EXP'
(nothing)
$ cat /proc/169/environ | tr '\\0' '\\n' | grep -E 'GIT_AUTHOR|CODER_AGENT_EXP'
(nothing)
$ env | grep -E 'GIT_AUTHOR|CODER_AGENT_EXP'
GIT_AUTHOR_NAME=...
GIT_COMMITTER_EMAIL=...
CODER_AGENT_EXP_SKILLS_DIRS=~/.agents/skills,.agents/skills
```

`GIT_AUTHOR_*` happened to work anyway because git only runs as a child of the agent (which gets the env via the manifest path). `CODER_AGENT_EXP_SKILLS_DIRS` did not work because only the agent itself reads it.

In our envbuilder workspaces, the agent process is exec'd by envbuilder inside the built container and inherits the container env. So to make agent-startup-time env vars visible, they must be in the container env we hand to envbuilder.

## Fix

Forward the entire `coder_agent.main.env` map into `envbuilder_env` via a new `agent_env` input on the `workspace-envbuilder` module. After this, `CODER_AGENT_EXP_SKILLS_DIRS` (and other `CODER_AGENT_EXP_*` vars) will land in `/proc/<agent_pid>/environ` and be picked up by `ReadEnvConfig`.

Merge order in the module keeps things sane:

`merge(var.agent_env, { module-owned keys... }, var.is_new_project ? {...} : {})`

so template-level `agent_env` cannot accidentally override module-owned keys like `CODER_AGENT_TOKEN`/`ENVBUILDER_*`, and the new-project flags remain authoritative for that lifecycle state.

## Verification after merge

After rebuilding a workspace with the new template version:

```
cat /proc/$(pgrep -of 'coder agent')/environ | tr '\\0' '\\n' | grep CODER_AGENT_EXP
# should show CODER_AGENT_EXP_SKILLS_DIRS=~/.agents/skills,.agents/skills
```

And skills under `~/.agents/skills` should appear in Coder Agents chats.