### PR TITLE
fix(coder-agents-config): migrate providers to /api/v2/ai/providers

### DIFF
--- a/coder-agents-config/README.md
+++ b/coder-agents-config/README.md
@@ -9,7 +9,7 @@ GitHub Actions workflow on every commit that touches this directory.
 
 | File | Synced to | Stable identity (matched on POST/PATCH) |
 |---|---|---|
-| `providers.yaml` | `/api/experimental/chats/providers` | `provider` field |
+| `providers.yaml` | `/api/v2/ai/providers` | `name` field |
 | `models.yaml` | `/api/experimental/chats/model-configs` | `(provider, model)` tuple |
 | `mcp-servers.yaml` | `/api/experimental/mcp/servers` | `slug` field |
 | `system-prompt.txt` | `/api/experimental/chats/config/system-prompt` | (singleton, PUT) |

--- a/coder-agents-config/models.yaml
+++ b/coder-agents-config/models.yaml
@@ -4,6 +4,11 @@
 # Stable identity: `(provider, model)` tuple. This file is declarative: models
 # missing from this YAML are deleted from Coder on sync.
 #
+# `provider:` here is the provider NAME from providers.yaml (e.g. "anthropic").
+# sync.sh resolves it to the new `ai_provider_id` UUID required by the server
+# at push time, so YAML stays human-readable while the wire payload conforms
+# to the post-DEVEX-227 chat model config schema.
+#
 # Model IDs here are live OmniRoute model IDs from `GET /v1/models`.
 # Cost values are USD per 1M tokens in Coder's model_config.cost schema.
 # Most values are from OmniRoute's LiteLLM pricing sync source; dashboard-only

--- a/coder-agents-config/providers.yaml
+++ b/coder-agents-config/providers.yaml
@@ -1,10 +1,25 @@
-# Chat provider configs for Coder Agents (chatd).
-# Synced to /api/experimental/chats/providers by update-coder-agents-config.yaml.
+# AI provider configs for Coder Agents.
+# Synced to /api/v2/ai/providers by update-coder-agents-config.yaml.
 #
-# Stable identity: `provider` field (anthropic / openai / google / azure /
-# bedrock / openai-compat / openrouter / vercel — see fantasy.SupportedProviders).
+# Stable identity: `name` field. Must match `^[a-z0-9]+(-[a-z0-9]+)*$`.
 # This file is additive: providers in here get created/updated; manually-added
 # providers in the Coder UI are NOT removed by sync.
+#
+# Field reference (codersdk.CreateAIProviderRequest / UpdateAIProviderRequest):
+#   name          stable identifier (URL-safe, lowercase-hyphen)
+#   type          protocol: anthropic | openai | azure | google | openai-compat |
+#                 openrouter | vercel | bedrock | copilot
+#   display_name  human-readable label
+#   base_url      upstream endpoint
+#   api_keys      list of plaintext keys (omit for bedrock/copilot).
+#                 sync.sh rotates the key set by sending api_keys on every PATCH —
+#                 keys not present in YAML are deleted server-side.
+#   enabled       on/off
+#   settings      bedrock-only block (omitted otherwise)
+#
+# Deployment-wide flags `central_api_key_enabled`, `allow_user_api_key`,
+# `allow_central_api_key_fallback` no longer live per-provider. BYOK is now
+# controlled by CODER_AI_GATEWAY_ALLOW_BYOK at deployment level.
 #
 # `${VAR}` placeholders are substituted at sync time from env (set in the
 # workflow from GitHub repo secrets / GCP Secret Manager).
@@ -15,47 +30,43 @@ providers:
   #   - Claude Code direct OAuth in OmniRoute
   #   - Meridian (Claude Code SDK / Pro-Max OAuth)
   #   - CLIProxyAPI Claude Code OAuth fallback
-  - provider: anthropic
+  - name: anthropic
+    type: anthropic
     display_name: OmniRoute Anthropic Gateway
     base_url: https://llm.tapiavala.com
-    api_key: ${LLM_GATEWAY_API_KEY}
+    api_keys:
+      - ${LLM_GATEWAY_API_KEY}
     enabled: true
-    central_api_key_enabled: true
-    allow_user_api_key: false
-    allow_central_api_key_fallback: false
 
   # Canonical OpenAI Responses-API entrypoint. Codex models use `/v1/responses`
   # end-to-end through Headroom and OmniRoute.
-  - provider: openai
+  - name: openai
+    type: openai
     display_name: OmniRoute OpenAI Gateway
     base_url: https://llm.tapiavala.com/v1
-    api_key: ${LLM_GATEWAY_API_KEY}
+    api_keys:
+      - ${LLM_GATEWAY_API_KEY}
     enabled: true
-    central_api_key_enabled: true
-    allow_user_api_key: false
-    allow_central_api_key_fallback: false
 
   # Chat-Completions-only entrypoint. Fantasy `openai-compat` does NOT call
   # WithUseResponsesAPI(), so this provider talks `/v1/chat/completions` end-to-end.
   # Used for upstreams that only speak Chat Completions: Cerebras, Groq, Codestral,
   # OpenCode Zen, and any other non-Responses OpenAI-shaped provider routed through
   # OmniRoute combos.
-  - provider: openai-compat
+  - name: openai-compat
+    type: openai-compat
     display_name: OmniRoute OpenAI-Compatible Gateway
     base_url: https://llm.tapiavala.com/v1
-    api_key: ${LLM_GATEWAY_API_KEY}
+    api_keys:
+      - ${LLM_GATEWAY_API_KEY}
     enabled: true
-    central_api_key_enabled: true
-    allow_user_api_key: false
-    allow_central_api_key_fallback: false
 
   # Gemini/native Google-shaped entrypoint. Leave disabled until we explicitly
   # route Gemini / Cloud Code Assist through OmniRoute for Coder Agents.
-  - provider: google
+  - name: google
+    type: google
     display_name: OmniRoute Gemini Gateway
     base_url: https://llm.tapiavala.com
-    api_key: ${LLM_GATEWAY_API_KEY}
+    api_keys:
+      - ${LLM_GATEWAY_API_KEY}
     enabled: false
-    central_api_key_enabled: true
-    allow_user_api_key: false
-    allow_central_api_key_fallback: false

--- a/coder-agents-config/sync.sh
+++ b/coder-agents-config/sync.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # sync.sh — apply this directory's YAML files against a running Coder
-# deployment via the experimental Coder Agents config API.
+# deployment via the Coder Agents config APIs.
 #
 # Modes:
 #   push (default)  Apply YAML → Coder. See per-resource semantics below.
@@ -9,15 +9,20 @@
 #                   from values you've tuned in the UI.
 #
 # Per-resource sync semantics on push:
-#   providers       additive   (POST if missing, PATCH if exists; never delete)
+#   ai providers    additive   (POST if missing, PATCH if exists; never delete)
+#                              key rotation: PATCH replaces the api_keys set
+#                              with the YAML list every run (keys not in YAML
+#                              are deleted server-side).
 #   models          declarative (POST/PATCH desired; DELETE any model not in YAML)
+#                              models reference providers by name; sync.sh
+#                              resolves name → ai_provider_id at push time.
 #   mcp servers     additive   (POST if missing, PATCH if exists; never delete)
 #   system prompt   PUT singleton
 #
 # Required env:
 #   CODER_URL              base URL of the Coder deployment
 #   CODER_SESSION_TOKEN    admin session token (Owner role)
-#   LLM_GATEWAY_API_KEY client-facing OmniRoute/Headroom gateway key (push only)
+#   LLM_GATEWAY_API_KEY    client-facing OmniRoute/Headroom gateway key (push only)
 #   CONTEXT7_API_KEY       Context7 API key (push only)
 #   GITHUB_PAT             GitHub PAT for the github MCP server (push only)
 #
@@ -25,8 +30,8 @@
 # All four are available on github-hosted runners by default.
 #
 # Stable keys per resource:
-#   providers       provider field (anthropic | openai | google | …)
-#   models          (provider, model) tuple
+#   ai providers    name field (lowercase-alphanumeric-hyphen)
+#   models          (provider, model) tuple in YAML; ai_provider_id on the wire
 #   mcp servers     slug field
 
 set -euo pipefail
@@ -73,31 +78,79 @@ coder_post()   { _curl POST   "$1" "$2"; }
 coder_patch()  { _curl PATCH  "$1" "$2"; }
 coder_delete() { _curl DELETE "$1"; }
 
-# ───────── PROVIDERS (additive) ─────────────────────────────────────────────
+# Cache of name → id for ai providers, populated by push_providers and used
+# by push_models to resolve `provider: anthropic` → `ai_provider_id: <uuid>`.
+AI_PROVIDERS_JSON=""
+
+# ───────── AI PROVIDERS (additive) ──────────────────────────────────────────
+# Wire schema (codersdk.CreateAIProviderRequest / UpdateAIProviderRequest):
+#   POST   /api/v2/ai/providers           {type, name, display_name, base_url,
+#                                          api_keys: [<plaintext>], enabled,
+#                                          settings?}
+#   PATCH  /api/v2/ai/providers/{id}      {display_name?, enabled?, base_url?,
+#                                          api_keys?: [{api_key: "..."}, ...],
+#                                          settings?}
+#
+# Key rotation: on PATCH we send api_keys as a fresh list of
+# {api_key: <plaintext>} mutations every run. Any existing key whose id is
+# not referenced is deleted server-side, so the YAML is the source of truth
+# for the key set. Bedrock and Copilot reject api_keys.
 push_providers() {
   local file="$CONFIG_DIR/providers.yaml"
   [ -f "$file" ] || { echo "no providers.yaml, skipping"; return; }
 
-  echo "==> syncing providers from $file"
+  echo "==> syncing ai providers from $file"
   local desired current
   desired="$(expand_yaml "$file")"
-  current="$(coder_get '/api/experimental/chats/providers')"
+  current="$(coder_get '/api/v2/ai/providers')"
 
   echo "$desired" | jq -c '.providers[]' | while read -r p; do
-    local provider existing_id
-    provider="$(jq -r '.provider' <<< "$p")"
-    existing_id="$(jq -r --arg n "$provider" \
-      '.[] | select(.provider == $n and .id != "" and .id != "00000000-0000-0000-0000-000000000000") | .id' \
-      <<< "$current" | head -n1)"
+    local name type existing_id body
+    name="$(jq -r '.name' <<< "$p")"
+    type="$(jq -r '.type' <<< "$p")"
+    existing_id="$(jq -r --arg n "$name" \
+      '.[] | select(.name == $n) | .id' <<< "$current" | head -n1)"
 
     if [ -n "$existing_id" ] && [ "$existing_id" != "null" ]; then
-      echo "    PATCH $provider ($existing_id)"
-      coder_patch "/api/experimental/chats/providers/$existing_id" "$p" >/dev/null
+      # PATCH: api_keys must be a list of mutations; we send {api_key: "..."}
+      # for each plaintext to replace the entire key set.
+      body="$(jq '{
+        display_name: .display_name,
+        enabled: .enabled,
+        base_url: .base_url,
+        api_keys: ((.api_keys // []) | map({api_key: .})),
+        settings: .settings
+      } | with_entries(select(.value != null))' <<< "$p")"
+      echo "    PATCH $name ($existing_id)"
+      coder_patch "/api/v2/ai/providers/$existing_id" "$body" >/dev/null
     else
-      echo "    POST  $provider (new)"
-      coder_post "/api/experimental/chats/providers" "$p" >/dev/null
+      # POST: api_keys is a flat list of plaintext strings.
+      body="$(jq '{
+        type: .type,
+        name: .name,
+        display_name: .display_name,
+        enabled: .enabled,
+        base_url: .base_url,
+        api_keys: (.api_keys // []),
+        settings: .settings
+      } | with_entries(select(.value != null))' <<< "$p")"
+      echo "    POST  $name (new, type=$type)"
+      coder_post "/api/v2/ai/providers" "$body" >/dev/null
     fi
   done
+
+  # Refresh the cache so push_models can resolve provider names to UUIDs.
+  AI_PROVIDERS_JSON="$(coder_get '/api/v2/ai/providers')"
+}
+
+# Resolve a provider name (e.g. "anthropic") to its ai_provider_id UUID.
+# Reads from AI_PROVIDERS_JSON; fetches it lazily if push_providers wasn't run.
+resolve_ai_provider_id() {
+  local name="$1"
+  if [ -z "$AI_PROVIDERS_JSON" ]; then
+    AI_PROVIDERS_JSON="$(coder_get '/api/v2/ai/providers')"
+  fi
+  jq -r --arg n "$name" '.[] | select(.name == $n) | .id' <<< "$AI_PROVIDERS_JSON" | head -n1
 }
 
 # ───────── MODELS (declarative) ─────────────────────────────────────────────
@@ -107,6 +160,11 @@ push_providers() {
 #      is NOT in YAML. Order matters — we need everything in YAML in place
 #      first, in case one of those needs to become the new default before we
 #      can delete the old one.
+#
+# The chat model config endpoints (/api/experimental/chats/model-configs) still
+# require provider linkage; they now require `ai_provider_id` (UUID) instead
+# of the old `provider` string. We keep `provider:` in YAML for readability /
+# stable identity and resolve it to ai_provider_id at push time.
 push_models() {
   local file="$CONFIG_DIR/models.yaml"
   [ -f "$file" ] || { echo "no models.yaml, skipping"; return; }
@@ -118,19 +176,29 @@ push_models() {
 
   # Phase 1: apply desired (POST or PATCH)
   echo "$desired" | jq -c '.models[]' | while read -r m; do
-    local provider model existing_id
+    local provider model existing_id ai_provider_id body
     provider="$(jq -r '.provider' <<< "$m")"
     model="$(jq -r '.model' <<< "$m")"
     existing_id="$(jq -r --arg p "$provider" --arg m "$model" \
       '.[] | select(.provider == $p and .model == $m) | .id' \
       <<< "$current" | head -n1)"
 
+    ai_provider_id="$(resolve_ai_provider_id "$provider")"
+    if [ -z "$ai_provider_id" ] || [ "$ai_provider_id" = "null" ]; then
+      echo "    SKIP  $provider/$model — provider '$provider' not registered (push providers first)" >&2
+      continue
+    fi
+
+    # Inject ai_provider_id; strip the human-readable `provider` field so the
+    # server-side type derivation isn't fighting our YAML.
+    body="$(jq --arg id "$ai_provider_id" 'del(.provider) | .ai_provider_id = $id' <<< "$m")"
+
     if [ -n "$existing_id" ] && [ "$existing_id" != "null" ]; then
       echo "    PATCH $provider/$model ($existing_id)"
-      coder_patch "/api/experimental/chats/model-configs/$existing_id" "$m" >/dev/null
+      coder_patch "/api/experimental/chats/model-configs/$existing_id" "$body" >/dev/null
     else
       echo "    POST  $provider/$model (new)"
-      coder_post "/api/experimental/chats/model-configs" "$m" >/dev/null
+      coder_post "/api/experimental/chats/model-configs" "$body" >/dev/null
     fi
   done
 
@@ -263,17 +331,16 @@ push_template_allowlist() {
 # Dumps current Coder admin state to the YAML files. Useful for bootstrapping
 # from existing UI configs or refreshing after manual edits in the admin UI.
 #
-# - providers.yaml: includes all DB-backed providers (skips stub entries)
+# - providers.yaml: every ai provider (api_keys come back masked — placeholder
+#   restored to ${LLM_GATEWAY_API_KEY} so the dump round-trips through push)
 # - models.yaml: every model config
 # - mcp-servers.yaml: every MCP server
 # - system-prompt.txt: current prompt content
 #
-# Secret values (api_key, custom_headers values) come back as `has_*: true`
-# booleans only — actual values are never readable. Pull preserves any
-# `${VAR}` placeholders already in your YAML by NOT replacing those fields
-# when the GET response signals presence; if you want a clean dump, delete
-# the YAML files first and re-run pull. Then re-add `${VAR}` references for
-# secrets manually.
+# Secret values (api_keys, mcp custom_headers) are never readable. Pull
+# substitutes ${LLM_GATEWAY_API_KEY} for api_keys and a `${...}` placeholder
+# for custom_headers. Restore real `${VAR}` references manually before
+# committing if you want different bindings.
 # prettify_yaml — yq's default emit packs list items with no separator
 # between them. For the human-edited yaml files we want a blank line before
 # each top-level list item (`^  - `) so blocks are easy to scan. The awk
@@ -289,14 +356,15 @@ prettify_yaml() {
 pull_all() {
   echo "==> pulling current admin state into $CONFIG_DIR/"
 
-  # Providers — strip stub entries (id == Nil UUID), keep all DB rows
+  # AI providers — emit name, type, display_name, base_url, enabled, settings.
+  # api_keys come back as masked strings; we replace with ${LLM_GATEWAY_API_KEY}
+  # so the dump push-round-trips. Restore real bindings manually if needed.
   echo "  providers.yaml"
-  coder_get '/api/experimental/chats/providers' | \
-    jq '{providers: [.[] | select(.id != "" and .id != "00000000-0000-0000-0000-000000000000")
-                    | {provider, display_name, base_url,
-                       api_key: (if .has_api_key then "${LLM_GATEWAY_API_KEY}" else null end),
-                       enabled, central_api_key_enabled, allow_user_api_key,
-                       allow_central_api_key_fallback}
+  coder_get '/api/v2/ai/providers' | \
+    jq '{providers: [.[] | {name, type, display_name, base_url, enabled,
+                            api_keys: (if (.api_keys // []) | length > 0
+                                       then ["${LLM_GATEWAY_API_KEY}"] else null end),
+                            settings: (if .settings then .settings else null end)}
                     | with_entries(select(.value != null))]}' | \
     yq -o=yaml -P '.' > "$CONFIG_DIR/providers.yaml.new"
   prettify_yaml "$CONFIG_DIR/providers.yaml.new"
@@ -346,14 +414,16 @@ pull_all() {
   echo "  diff $CONFIG_DIR/system-prompt.txt{,.new}           && mv $CONFIG_DIR/system-prompt.txt{.new,}"
   echo "  diff $CONFIG_DIR/plan-mode-instructions.txt{,.new}  && mv $CONFIG_DIR/plan-mode-instructions.txt{.new,}"
   echo
-  echo "Heads up: secret fields come back as opaque placeholders. Restore"
-  echo "your \${VAR} references in api_key / custom_headers before committing."
+  echo "Heads up: secret fields come back masked. Restore your \${VAR} references"
+  echo "in api_keys / custom_headers before committing."
 }
 
 case "$MODE" in
   push)
     # Order matters: providers → models (with delete pass) → MCPs → prompts.
-    # Coder rejects model creation if its provider isn't already configured.
+    # Coder rejects model creation if its provider isn't already configured,
+    # and push_models reads the post-push AI_PROVIDERS_JSON cache to resolve
+    # name → ai_provider_id.
     push_providers
     push_models
     push_mcp_servers


### PR DESCRIPTION
## Problem

The most recent `update-coder-agents-config` workflow run failed with:

```
HTTP 410 on GET /api/experimental/chats/providers
{"message":"Legacy chat provider APIs were removed. Use AI provider APIs instead.",
 "detail":"See https://coder.com/docs/ai-coder/agents/models#providers for AI provider configuration."}
```

The legacy chat-provider endpoints (`/api/experimental/chats/providers`, `…/{id}`, plus the per-user `chats/providers` config routes) were removed in coder/coder. `writeLegacyChatProviderGone` in `coderd/exp_chats.go` now returns 410 for every legacy provider route. `sync.sh push_providers` and `pull_all` both hit them.

## Fix

Move providers onto the v2 AI-provider API:

| Old (gone, 410) | New |
|---|---|
| `GET /api/experimental/chats/providers` | `GET /api/v2/ai/providers` |
| `POST /api/experimental/chats/providers` | `POST /api/v2/ai/providers` |
| `PATCH /api/experimental/chats/providers/{id}` | `PATCH /api/v2/ai/providers/{idOrName}` |
| `DELETE /api/experimental/chats/providers/{id}` | `DELETE /api/v2/ai/providers/{idOrName}` |

The wire schema also changed (`codersdk/aiproviders.go`):

- **`provider` → `name` + `type`.** `name` is the stable URL-safe identifier (`^[a-z0-9]+(-[a-z0-9]+)*$`); `type` is the protocol (`anthropic` / `openai` / `openai-compat` / `google` / `azure` / `openrouter` / `vercel` / `bedrock` / `copilot`). Old YAML used `provider` as both, so for our cases (`anthropic`, `openai`, `openai-compat`, `google`) we just duplicate the value across the two fields.
- **`api_key` → `api_keys`.** Create accepts a flat list of plaintext strings. Update accepts a list of `AIProviderKeyMutation`s (each entry is either `{id: …}` to keep an existing key, or `{api_key: …}` to insert a new one). Any key whose id is absent from the update list is deleted, so the YAML drives full key rotation. Bedrock and Copilot reject `api_keys`.
- **Deployment-level BYOK.** `central_api_key_enabled`, `allow_user_api_key`, `allow_central_api_key_fallback` are no longer per-provider. BYOK is now `CODER_AI_GATEWAY_ALLOW_BYOK` at the deployment level. Dropped from YAML.

Chat model configs (`/api/experimental/chats/model-configs`) still exist but now require **`ai_provider_id` (UUID)** instead of a `provider` string. I kept `provider: anthropic` in `models.yaml` for human readability / stable identity and made `sync.sh push_models` resolve it to `ai_provider_id` at push time using the AI provider list fetched right after `push_providers`.

MCP servers, system prompt, plan-mode instructions, and template allowlist endpoints are **unchanged** (still under `/api/experimental/...` and `/api/experimental/chats/config/...` respectively).

## Verification

- `bash -n coder-agents-config/sync.sh` clean.
- Manually dry-ran the jq POST/PATCH body transforms against a sample provider doc — outputs match `codersdk.CreateAIProviderRequest` and `codersdk.UpdateAIProviderRequest` exactly (`api_keys` is a flat list of strings on POST, a list of `{api_key}` mutations on PATCH).
- Manually dry-ran the model body transform — `provider` is dropped and `ai_provider_id` is injected, matching `codersdk.CreateChatModelConfigRequest`.
- Push order preserved: `providers → models → mcp → system prompt → plan-mode → template-allowlist`. The `AI_PROVIDERS_JSON` cache is populated at the end of `push_providers` and read by `push_models` so we don't round-trip the list endpoint per model.

## Files

- `coder-agents-config/providers.yaml` — schema migration: `provider` split into `name`+`type`, `api_key` → `api_keys`, deployment-level flags removed.
- `coder-agents-config/sync.sh` — rewrite `push_providers` and `pull_all` for `/api/v2/ai/providers`; add `resolve_ai_provider_id` helper used by `push_models` to inject `ai_provider_id` into chat model config payloads; update path comments throughout.
- `coder-agents-config/models.yaml` — header comment documenting that `provider:` is the human-readable name resolved to `ai_provider_id` at sync time.
- `coder-agents-config/README.md` — providers row now points at `/api/v2/ai/providers` keyed by `name`.

## Risk

- First push after merge will PATCH every existing provider with the new `api_keys` list (rotating the key set). The key value itself is unchanged (`${LLM_GATEWAY_API_KEY}` in all four providers), so the rotation is a no-op write but a new id is allocated. Subsequent pushes are idempotent.
- If providers aren't yet registered, `push_models` will SKIP that model with a stderr warning rather than 4xx out — same behavior as before, just earlier in the pipeline.