### PR TITLE
Set Ruff line-length to 120 for all Python workspaces

### DIFF
--- a/workspace-images/python-shared/settings.d/30-python.json
+++ b/workspace-images/python-shared/settings.d/30-python.json
@@ -8,6 +8,7 @@
         "source.organizeImports.ruff": "explicit"
       }
     },
+    "ruff.lineLength": 120,
     "python.languageServer": "None",
     "python.testing.pytestEnabled": true,
     "python.testing.unittestEnabled": false,

--- a/workspace-images/python-shared/settings.d/30-python.json
+++ b/workspace-images/python-shared/settings.d/30-python.json
@@ -8,7 +8,7 @@
         "source.organizeImports.ruff": "explicit"
       }
     },
-    "ruff.lineLength": 120,
+    "ruff.lineLength": 160,
     "python.languageServer": "None",
     "python.testing.pytestEnabled": true,
     "python.testing.unittestEnabled": false,


### PR DESCRIPTION
## What

Adds `ruff.lineLength: 120` to `workspace-images/python-shared/settings.d/30-python.json` (the `.machine` manifest).

## Why

The Ruff formatter (`charliermarsh.ruff`) defaults to **88** columns, which wraps/indents long lines. This sets a consistent **120** wrap point across all newly created workspaces instead of fixing it per-project.

## How it propagates

- `python-dev` and `fullstack-dev` Dockerfiles `COPY python-shared/settings.d/` → `/usr/local/share/workspace-settings.d/`.
- `base-dev/init.d/26-settings-apply.sh` merges `.machine` manifests into VS Code Machine settings on **every boot**, so existing and new workspaces pick it up on next start.

## Notes

- `ruff.lineLength` controls **both** the formatter wrap point and the E501 linter limit.
- Ruff won't auto-rejoin lines that are already split; reformat affected files to collapse them.
- Takes effect in a workspace after rebuilding the image (or on next boot for the machine-settings merge).