### PR TITLE
fix(ci): bump container-retention-policy to v3.1.0 for new GITHUB_TOKEN format

### DIFF
--- a/.github/workflows/build-agentmemory.yaml
+++ b/.github/workflows/build-agentmemory.yaml
@@ -133,7 +133,7 @@ jobs:
           fi
 
       - name: Clean up old GHCR versions (manifests + per-arch digests)
-        uses: snok/container-retention-policy@v3.0.1
+        uses: snok/container-retention-policy@v3.1.0
         with:
           account: user
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-base-dev.yaml
+++ b/.github/workflows/build-base-dev.yaml
@@ -138,7 +138,7 @@ jobs:
           fi
 
       - name: Clean up old GHCR versions (manifests + per-arch digests)
-        uses: snok/container-retention-policy@v3.0.1
+        uses: snok/container-retention-policy@v3.1.0
         with:
           # Personal account; if this is an org, use the org name instead
           account: user

--- a/.github/workflows/build-cliproxy.yaml
+++ b/.github/workflows/build-cliproxy.yaml
@@ -133,7 +133,7 @@ jobs:
           fi
 
       - name: Clean up old GHCR versions (manifests + per-arch digests)
-        uses: snok/container-retention-policy@v3.0.1
+        uses: snok/container-retention-policy@v3.1.0
         with:
           account: user
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-cpp-dev.yaml
+++ b/.github/workflows/build-cpp-dev.yaml
@@ -144,7 +144,7 @@ jobs:
           fi
 
       - name: Clean up old GHCR versions (manifests + per-arch digests)
-        uses: snok/container-retention-policy@v3.0.1
+        uses: snok/container-retention-policy@v3.1.0
         with:
           # Personal account; if this is an org, use the org name instead
           account: user

--- a/.github/workflows/build-fullstack-dev.yaml
+++ b/.github/workflows/build-fullstack-dev.yaml
@@ -147,7 +147,7 @@ jobs:
           fi
 
       - name: Clean up old GHCR versions (manifests + per-arch digests)
-        uses: snok/container-retention-policy@v3.0.1
+        uses: snok/container-retention-policy@v3.1.0
         with:
           # Personal account; if this is an org, use the org name instead
           account: user

--- a/.github/workflows/build-hapi-hub.yaml
+++ b/.github/workflows/build-hapi-hub.yaml
@@ -137,7 +137,7 @@ jobs:
           fi
 
       - name: Clean up old GHCR versions (manifests + per-arch digests)
-        uses: snok/container-retention-policy@v3.0.1
+        uses: snok/container-retention-policy@v3.1.0
         with:
           # Personal account; if this is an org, use the org name instead
           account: user

--- a/.github/workflows/build-python-dev.yaml
+++ b/.github/workflows/build-python-dev.yaml
@@ -145,7 +145,7 @@ jobs:
           fi
 
       - name: Clean up old GHCR versions (manifests + per-arch digests)
-        uses: snok/container-retention-policy@v3.0.1
+        uses: snok/container-retention-policy@v3.1.0
         with:
           # Personal account; if this is an org, use the org name instead
           account: user

--- a/.github/workflows/build-rust-dev.yaml
+++ b/.github/workflows/build-rust-dev.yaml
@@ -144,7 +144,7 @@ jobs:
           fi
 
       - name: Clean up old GHCR versions (manifests + per-arch digests)
-        uses: snok/container-retention-policy@v3.0.1
+        uses: snok/container-retention-policy@v3.1.0
         with:
           # Personal account; if this is an org, use the org name instead
           account: user

--- a/.github/workflows/build-vite-dev.yaml
+++ b/.github/workflows/build-vite-dev.yaml
@@ -144,7 +144,7 @@ jobs:
           fi
 
       - name: Clean up old GHCR versions (manifests + per-arch digests)
-        uses: snok/container-retention-policy@v3.0.1
+        uses: snok/container-retention-policy@v3.1.0
         with:
           # Personal account; if this is an org, use the org name instead
           account: user


### PR DESCRIPTION
## Problem

All 9 image build workflows fail on the GHCR cleanup step:

```
error: invalid value '***' for '--token <TOKEN>': The token value is not valid.
Must be $GITHUB_TOKEN, a classic personal access token (prefixed by 'ghp') or
oauth token (prefixed by 'gho').
```

## Root cause

GitHub rolled out a **new JWT-based format** for `GITHUB_TOKEN` / GitHub App installation tokens: `ghs_<APPID>_<JWT>` (~520 chars), replacing the legacy `ghs_` + 36 alphanumeric chars.

The pinned **`snok/container-retention-policy@v3.0.1`** binary validates the token with:

```rust
// src/cli/models.rs @ v3.0.1
Regex::new(r"ghs_[a-zA-Z0-9]{36}$")  // legacy format only
```

The new token contains `_` and `.` characters and is far longer, so it fails validation → the masked `***` value is rejected.

**`v3.1.0`** adds a matcher for the new format:

```rust
// src/cli/models.rs @ v3.0.1
static RE_TEMPORAL_JWT: LazyLock<Regex> =
    LazyLock::new(|| Regex::new(r"^ghs_[0-9]+_[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+$").unwrap());
```

## Fix

Bump the action from `v3.0.1` → `v3.1.0` in all 9 build workflows. No PAT or GitHub App token required — the existing `secrets.GITHUB_TOKEN` works once the action understands the new format.

### Files changed
- `.github/workflows/build-base-dev.yaml`
- `.github/workflows/build-fullstack-dev.yaml`
- `.github/workflows/build-vite-dev.yaml`
- `.github/workflows/build-agentmemory.yaml`
- `.github/workflows/build-rust-dev.yaml`
- `.github/workflows/build-python-dev.yaml`
- `.github/workflows/build-cpp-dev.yaml`
- `.github/workflows/build-cliproxy.yaml`
- `.github/workflows/build-hapi-hub.yaml`