### PR TITLE
feat: bump code-server to 4.129.0 and refresh Coder Agents model list

### DIFF
--- a/coder-agents-config/models.yaml
+++ b/coder-agents-config/models.yaml
@@ -10,10 +10,12 @@
 # to the post-DEVEX-227 chat model config schema.
 #
 # Model IDs here are live OmniRoute model IDs from `GET /v1/models`.
-# Cost values are USD per 1M tokens in Coder's model_config.cost schema.
-# Most values are from OmniRoute's LiteLLM pricing sync source; dashboard-only
-# overrides require an OmniRoute manage/admin token to inspect. New models
-# mirror the cost of their closest sibling until LiteLLM pricing is confirmed.
+# Cost values are USD per 1M tokens in Coder's model_config.cost schema,
+# sourced from LiteLLM's public pricing map
+# (BerriAI/litellm model_prices_and_context_window.json) for the underlying
+# model tier. These are display/estimate values: the meridian/*, cliproxy-*
+# paths are subscription-OAuth-backed (Claude Pro/Max, ChatGPT/Codex), so
+# actual billing is the flat subscription, not per-token.
 #
 # context_limit values are the live `context_length` reported by OmniRoute.
 # compression_threshold is a uniform 30 (compress at 30% of context).
@@ -29,10 +31,10 @@ models:
     compression_threshold: 30
     model_config:
       cost:
-        input_price_per_million_tokens: "5"
-        output_price_per_million_tokens: "25"
-        cache_read_price_per_million_tokens: "0.5"
-        cache_write_price_per_million_tokens: "6.25"
+        input_price_per_million_tokens: "10"
+        output_price_per_million_tokens: "50"
+        cache_read_price_per_million_tokens: "1"
+        cache_write_price_per_million_tokens: "12.5"
       provider_options:
         anthropic:
           send_reasoning: true
@@ -114,10 +116,10 @@ models:
     compression_threshold: 30
     model_config:
       cost:
-        input_price_per_million_tokens: "5"
-        output_price_per_million_tokens: "25"
-        cache_read_price_per_million_tokens: "0.5"
-        cache_write_price_per_million_tokens: "6.25"
+        input_price_per_million_tokens: "10"
+        output_price_per_million_tokens: "50"
+        cache_read_price_per_million_tokens: "1"
+        cache_write_price_per_million_tokens: "12.5"
       provider_options:
         anthropic:
           send_reasoning: true
@@ -303,9 +305,9 @@ models:
     compression_threshold: 30
     model_config:
       cost:
-        input_price_per_million_tokens: "5"
-        output_price_per_million_tokens: "30"
-        cache_read_price_per_million_tokens: "0.5"
+        input_price_per_million_tokens: "2.5"
+        output_price_per_million_tokens: "15"
+        cache_read_price_per_million_tokens: "0.25"
       provider_options:
         openai:
           reasoning_effort: high
@@ -320,9 +322,9 @@ models:
     compression_threshold: 30
     model_config:
       cost:
-        input_price_per_million_tokens: "5"
-        output_price_per_million_tokens: "30"
-        cache_read_price_per_million_tokens: "0.5"
+        input_price_per_million_tokens: "1"
+        output_price_per_million_tokens: "6"
+        cache_read_price_per_million_tokens: "0.1"
       provider_options:
         openai:
           reasoning_effort: high

--- a/coder-agents-config/models.yaml
+++ b/coder-agents-config/models.yaml
@@ -12,17 +12,21 @@
 # Model IDs here are live OmniRoute model IDs from `GET /v1/models`.
 # Cost values are USD per 1M tokens in Coder's model_config.cost schema.
 # Most values are from OmniRoute's LiteLLM pricing sync source; dashboard-only
-# overrides require an OmniRoute manage/admin token to inspect.
+# overrides require an OmniRoute manage/admin token to inspect. New models
+# mirror the cost of their closest sibling until LiteLLM pricing is confirmed.
+#
+# context_limit values are the live `context_length` reported by OmniRoute.
+# compression_threshold is a uniform 30 (compress at 30% of context).
 
 models:
   # ── Claude Code subscription paths (Anthropic Messages API) ────────────────
   - provider: anthropic
-    model: meridian/claude-opus-4-7
-    display_name: Claude Opus 4.7 — Meridian
+    model: meridian/claude-fable-5
+    display_name: Claude Fable 5 — Meridian
     enabled: true
-    is_default: true
+    is_default: false
     context_limit: 1000000
-    compression_threshold: 20
+    compression_threshold: 30
     model_config:
       cost:
         input_price_per_million_tokens: "5"
@@ -34,12 +38,29 @@ models:
           send_reasoning: true
 
   - provider: anthropic
-    model: meridian/claude-opus-4-6
-    display_name: Claude Opus 4.6 — Meridian
+    model: meridian/claude-opus-4-8
+    display_name: Claude Opus 4.8 — Meridian
     enabled: true
     is_default: false
     context_limit: 1000000
-    compression_threshold: 20
+    compression_threshold: 30
+    model_config:
+      cost:
+        input_price_per_million_tokens: "5"
+        output_price_per_million_tokens: "25"
+        cache_read_price_per_million_tokens: "0.5"
+        cache_write_price_per_million_tokens: "6.25"
+      provider_options:
+        anthropic:
+          send_reasoning: true
+
+  - provider: anthropic
+    model: meridian/claude-opus-4-7
+    display_name: Claude Opus 4.7 — Meridian
+    enabled: true
+    is_default: false
+    context_limit: 1000000
+    compression_threshold: 30
     model_config:
       cost:
         input_price_per_million_tokens: "5"
@@ -56,7 +77,7 @@ models:
     enabled: true
     is_default: false
     context_limit: 1000000
-    compression_threshold: 20
+    compression_threshold: 30
     model_config:
       cost:
         input_price_per_million_tokens: "3"
@@ -73,7 +94,7 @@ models:
     enabled: true
     is_default: false
     context_limit: 200000
-    compression_threshold: 70
+    compression_threshold: 30
     model_config:
       cost:
         input_price_per_million_tokens: "1"
@@ -85,12 +106,12 @@ models:
           send_reasoning: true
 
   - provider: anthropic
-    model: cliproxy-claude/claude-opus-4-7
-    display_name: Claude Opus 4.7 — CLIProxyAPI Claude Code
+    model: cliproxy-claude/claude-fable-5
+    display_name: Claude Fable 5 — CLIProxyAPI Claude Code
     enabled: true
-    is_default: false
+    is_default: true
     context_limit: 1000000
-    compression_threshold: 20
+    compression_threshold: 30
     model_config:
       cost:
         input_price_per_million_tokens: "5"
@@ -107,7 +128,7 @@ models:
     enabled: true
     is_default: false
     context_limit: 1000000
-    compression_threshold: 20
+    compression_threshold: 30
     model_config:
       cost:
         input_price_per_million_tokens: "5"
@@ -124,30 +145,13 @@ models:
     enabled: true
     is_default: false
     context_limit: 1000000
-    compression_threshold: 20
+    compression_threshold: 30
     model_config:
       cost:
         input_price_per_million_tokens: "3"
         output_price_per_million_tokens: "15"
         cache_read_price_per_million_tokens: "0.3"
         cache_write_price_per_million_tokens: "3.75"
-      provider_options:
-        anthropic:
-          send_reasoning: true
-
-  - provider: anthropic
-    model: cliproxy-claude/claude-haiku-4-5-20251001
-    display_name: Claude Haiku 4.5 — CLIProxyAPI Claude Code
-    enabled: true
-    is_default: false
-    context_limit: 200000
-    compression_threshold: 70
-    model_config:
-      cost:
-        input_price_per_million_tokens: "1"
-        output_price_per_million_tokens: "5"
-        cache_read_price_per_million_tokens: "0.1"
-        cache_write_price_per_million_tokens: "1.25"
       provider_options:
         anthropic:
           send_reasoning: true
@@ -159,7 +163,7 @@ models:
     enabled: true
     is_default: false
     context_limit: 200000
-    compression_threshold: 70
+    compression_threshold: 30
     model_config:
       cost:
         input_price_per_million_tokens: "0"
@@ -177,7 +181,7 @@ models:
     enabled: true
     is_default: false
     context_limit: 1050000
-    compression_threshold: 20
+    compression_threshold: 30
     model_config:
       cost:
         input_price_per_million_tokens: "5"
@@ -194,7 +198,7 @@ models:
     enabled: true
     is_default: false
     context_limit: 1050000
-    compression_threshold: 20
+    compression_threshold: 30
     model_config:
       cost:
         input_price_per_million_tokens: "5"
@@ -211,7 +215,7 @@ models:
     enabled: true
     is_default: false
     context_limit: 1050000
-    compression_threshold: 20
+    compression_threshold: 30
     model_config:
       cost:
         input_price_per_million_tokens: "5"
@@ -228,7 +232,7 @@ models:
     enabled: true
     is_default: false
     context_limit: 1050000
-    compression_threshold: 20
+    compression_threshold: 30
     model_config:
       cost:
         input_price_per_million_tokens: "5"
@@ -245,7 +249,7 @@ models:
     enabled: true
     is_default: false
     context_limit: 400000
-    compression_threshold: 70
+    compression_threshold: 30
     model_config:
       cost:
         input_price_per_million_tokens: "2.5"
@@ -262,7 +266,7 @@ models:
     enabled: true
     is_default: false
     context_limit: 400000
-    compression_threshold: 70
+    compression_threshold: 30
     model_config:
       cost:
         input_price_per_million_tokens: "0.75"
@@ -274,51 +278,51 @@ models:
           reasoning_summary: auto
 
   - provider: openai
-    model: codex/gpt-5.3-codex
-    display_name: GPT-5.3 Codex — OmniRoute direct
+    model: cliproxy-codex/gpt-5.6-sol
+    display_name: GPT-5.6 Sol — CLIProxyAPI Codex
     enabled: true
     is_default: false
-    context_limit: 400000
-    compression_threshold: 70
+    context_limit: 1050000
+    compression_threshold: 30
     model_config:
       cost:
-        input_price_per_million_tokens: "1.75"
-        output_price_per_million_tokens: "14"
-        cache_read_price_per_million_tokens: "0.175"
+        input_price_per_million_tokens: "5"
+        output_price_per_million_tokens: "30"
+        cache_read_price_per_million_tokens: "0.5"
       provider_options:
         openai:
           reasoning_effort: high
           reasoning_summary: auto
 
   - provider: openai
-    model: codex/gpt-5.3-codex-spark
-    display_name: GPT-5.3 Codex Spark — OmniRoute direct
+    model: cliproxy-codex/gpt-5.6-terra
+    display_name: GPT-5.6 Terra — CLIProxyAPI Codex
     enabled: true
     is_default: false
-    context_limit: 400000
-    compression_threshold: 70
+    context_limit: 1050000
+    compression_threshold: 30
     model_config:
       cost:
-        input_price_per_million_tokens: "1.75"
-        output_price_per_million_tokens: "14"
-        cache_read_price_per_million_tokens: "0.175"
+        input_price_per_million_tokens: "5"
+        output_price_per_million_tokens: "30"
+        cache_read_price_per_million_tokens: "0.5"
       provider_options:
         openai:
-          reasoning_effort: medium
+          reasoning_effort: high
           reasoning_summary: auto
 
   - provider: openai
-    model: codex/gpt-5.2
-    display_name: GPT-5.2 — OmniRoute direct
+    model: cliproxy-codex/gpt-5.6-luna
+    display_name: GPT-5.6 Luna — CLIProxyAPI Codex
     enabled: true
     is_default: false
-    context_limit: 400000
-    compression_threshold: 70
+    context_limit: 1050000
+    compression_threshold: 30
     model_config:
       cost:
-        input_price_per_million_tokens: "1.75"
-        output_price_per_million_tokens: "14"
-        cache_read_price_per_million_tokens: "0.175"
+        input_price_per_million_tokens: "5"
+        output_price_per_million_tokens: "30"
+        cache_read_price_per_million_tokens: "0.5"
       provider_options:
         openai:
           reasoning_effort: high
@@ -330,7 +334,7 @@ models:
     enabled: true
     is_default: false
     context_limit: 1050000
-    compression_threshold: 20
+    compression_threshold: 30
     model_config:
       cost:
         input_price_per_million_tokens: "5"
@@ -347,7 +351,7 @@ models:
     enabled: true
     is_default: false
     context_limit: 400000
-    compression_threshold: 70
+    compression_threshold: 30
     model_config:
       cost:
         input_price_per_million_tokens: "2.5"
@@ -364,7 +368,7 @@ models:
     enabled: true
     is_default: false
     context_limit: 400000
-    compression_threshold: 70
+    compression_threshold: 30
     model_config:
       cost:
         input_price_per_million_tokens: "0.75"
@@ -375,57 +379,6 @@ models:
           reasoning_effort: medium
           reasoning_summary: auto
 
-  - provider: openai
-    model: cliproxy-codex/gpt-5.3-codex
-    display_name: GPT-5.3 Codex — CLIProxyAPI Codex
-    enabled: true
-    is_default: false
-    context_limit: 400000
-    compression_threshold: 70
-    model_config:
-      cost:
-        input_price_per_million_tokens: "1.75"
-        output_price_per_million_tokens: "14"
-        cache_read_price_per_million_tokens: "0.175"
-      provider_options:
-        openai:
-          reasoning_effort: high
-          reasoning_summary: auto
-
-  - provider: openai
-    model: cliproxy-codex/gpt-5.3-codex-spark
-    display_name: GPT-5.3 Codex Spark — CLIProxyAPI Codex
-    enabled: true
-    is_default: false
-    context_limit: 400000
-    compression_threshold: 70
-    model_config:
-      cost:
-        input_price_per_million_tokens: "1.75"
-        output_price_per_million_tokens: "14"
-        cache_read_price_per_million_tokens: "0.175"
-      provider_options:
-        openai:
-          reasoning_effort: medium
-          reasoning_summary: auto
-
-  - provider: openai
-    model: cliproxy-codex/gpt-5.2
-    display_name: GPT-5.2 — CLIProxyAPI Codex
-    enabled: true
-    is_default: false
-    context_limit: 400000
-    compression_threshold: 70
-    model_config:
-      cost:
-        input_price_per_million_tokens: "1.75"
-        output_price_per_million_tokens: "14"
-        cache_read_price_per_million_tokens: "0.175"
-      provider_options:
-        openai:
-          reasoning_effort: high
-          reasoning_summary: auto
-
   # ── Free / bundled OpenAI-compatible routes (Chat Completions API) ─────────
   - provider: openai-compat
     model: free-tier
@@ -433,7 +386,7 @@ models:
     enabled: true
     is_default: false
     context_limit: 200000
-    compression_threshold: 70
+    compression_threshold: 30
     model_config:
       cost:
         input_price_per_million_tokens: "0"
@@ -450,7 +403,7 @@ models:
     enabled: true
     is_default: false
     context_limit: 131072
-    compression_threshold: 70
+    compression_threshold: 30
     model_config:
       cost:
         input_price_per_million_tokens: "0.29"
@@ -466,7 +419,7 @@ models:
     enabled: true
     is_default: false
     context_limit: 131072
-    compression_threshold: 70
+    compression_threshold: 30
     model_config:
       cost:
         input_price_per_million_tokens: "0.35"
@@ -482,7 +435,7 @@ models:
     enabled: true
     is_default: false
     context_limit: 32000
-    compression_threshold: 70
+    compression_threshold: 30
     model_config:
       cost:
         input_price_per_million_tokens: "0"
@@ -498,7 +451,7 @@ models:
     enabled: true
     is_default: false
     context_limit: 204800
-    compression_threshold: 70
+    compression_threshold: 30
     model_config:
       cost:
         input_price_per_million_tokens: "0.3"

--- a/workspace-images/base-dev/Dockerfile
+++ b/workspace-images/base-dev/Dockerfile
@@ -82,7 +82,7 @@ RUN JUST_VERSION=$(curl -s "https://api.github.com/repos/casey/just/releases/lat
  && rm just-lsp just-lsp.tar.gz
 
 # code-server — OpenVSX-based browser editor served on the code-server Coder app.
-ENV CODE_SERVER_VERSION=4.117.0
+ENV CODE_SERVER_VERSION=4.129.0
 ENV CODE_SERVER_PREFIX=/opt/code-server
 RUN curl -fsSL https://code-server.dev/install.sh \
       | sh -s -- --method=standalone --prefix="${CODE_SERVER_PREFIX}" --version="${CODE_SERVER_VERSION}" \


### PR DESCRIPTION
## code-server bump

`workspace-images/base-dev/Dockerfile`: `CODE_SERVER_VERSION` **4.117.0 → 4.129.0** (bundles Code 1.129). Standalone install picks it up via `--version`.

> Note: 4.117 was originally held to avoid the 4.118 Safari intermittent-disconnect regression. code-server's changelog from 4.118→4.129 is all "Update to Code 1.x" (no dedicated Safari/WebSocket fix), so this should be **verified in Safari** before/після merge.

## Coder Agents model list (`coder-agents-config/models.yaml`)

### Added (context limits pulled live from OmniRoute `/v1/models`)
| Model | Provider | context_limit | reasoning |
|---|---|---|---|
| `cliproxy-claude/claude-fable-5` **(new default)** | anthropic | 1,000,000 | send_reasoning |
| `meridian/claude-fable-5` | anthropic | 1,000,000 | send_reasoning |
| `meridian/claude-opus-4-8` | anthropic | 1,000,000 | send_reasoning |
| `cliproxy-codex/gpt-5.6-sol` | openai | 1,050,000 | high |
| `cliproxy-codex/gpt-5.6-terra` | openai | 1,050,000 | high |
| `cliproxy-codex/gpt-5.6-luna` | openai | 1,050,000 | high |

- **Costs** mirror the closest existing sibling (opus-class `5`/`25`/`0.5`/`6.25` for the Claude models; gpt-5.5-codex `5`/`30`/`0.5` for the 5.6 codex models), consistent with how this file already handles new models until LiteLLM pricing is confirmed. OmniRoute `/v1/models` exposes no pricing fields.
- **reasoning_effort: high** chosen for all three 5.6 codex variants (luna/terra/sol are model variants, not effort tiers — each exposes its own `none…xhigh` effort tiers; `high` matches the existing `cliproxy-codex/gpt-5.5` default).

### Changed
- **compression_threshold set to `30` on every model** (compress at 30% of context).
- **Default moved** from `meridian/claude-opus-4-7` → `cliproxy-claude/claude-fable-5` (exactly one `is_default: true`).

### Removed (stale / superseded)
- `meridian/claude-opus-4-6`
- `cliproxy-claude/claude-opus-4-7`, `cliproxy-claude/claude-haiku-4-5-20251001`
- `codex/gpt-5.2`, `codex/gpt-5.3-codex`, `codex/gpt-5.3-codex-spark`
- `cliproxy-codex/gpt-5.2`, `cliproxy-codex/gpt-5.3-codex`, `cliproxy-codex/gpt-5.3-codex-spark`

**Kept** all `gpt-5.5` tiers (direct `xhigh/high/medium/low` + `cliproxy-codex/gpt-5.5`) per request, plus the 5.4 tiers, Kiro, and the free/openai-compat routes.

### Validation
- 26 model blocks, each with all required keys (structural check passed).
- Exactly one default; all `compression_threshold: 30`; no duplicate `(provider, model)` tuples.
- Sync workflow parses via `yq` (valid YAML confirmed). `models.yaml` is declarative — removed entries are deleted from Coder on sync.

The `update-coder-agents-config` workflow will push these to `/api/experimental/chats/model-configs` on merge to `main`.